### PR TITLE
OT-102 #5 Re-enable avatar selection in profile view

### DIFF
--- a/lib/source/profile/profile.dart
+++ b/lib/source/profile/profile.dart
@@ -125,7 +125,7 @@ class _ProfileState extends State<ProfileView> {
               padding: EdgeInsets.symmetric(vertical: 24.0),
               child: buildAvatar(config),
             ),
-            getTextOrPlaceHolder(
+            buildTextOrPlaceHolder(
               text: config.username,
               style: TextStyle(fontSize: 24),
               align: TextAlign.center,
@@ -142,7 +142,7 @@ class _ProfileState extends State<ProfileView> {
             ),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 36.0),
-              child: getTextOrPlaceHolder(
+              child: buildTextOrPlaceHolder(
                 text: config.status,
                 align: TextAlign.center,
                 style: TextStyle(fontSize: 16),
@@ -163,8 +163,9 @@ class _ProfileState extends State<ProfileView> {
     );
   }
 
-  CircleAvatar buildAvatar(Config user) {
-    return user.avatarPath.isEmpty
+  CircleAvatar buildAvatar(Config config) {
+    var hasAvatarPath = config.avatarPath == null || config.avatarPath.isEmpty;
+    return hasAvatarPath
         ? CircleAvatar(
             maxRadius: profileAvatarMaxRadius,
             child: Icon(
@@ -173,8 +174,9 @@ class _ProfileState extends State<ProfileView> {
             ),
           )
         : CircleAvatar(
+            key: createKey(config.lastUpdate),
             maxRadius: profileAvatarMaxRadius,
-            backgroundImage: FileImage(File(user.avatarPath)),
+            backgroundImage: FileImage(File(config.avatarPath)),
           );
   }
 

--- a/lib/source/profile/user_bloc.dart
+++ b/lib/source/profile/user_bloc.dart
@@ -86,24 +86,25 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     dispatch(UserLoaded(config: config));
   }
 
-  void _saveUserPersonalData(UserPersonalDataChanged event) {
+  void _saveUserPersonalData(UserPersonalDataChanged event) async {
     Config config = Config();
-    config.setValue(Context.configDisplayName, event.username, true);
-    config.setValue(Context.configSelfStatus, event.status, true);
-    config.setValue(Context.configSelfAvatar, event.avatarPath, true);
+    config.setValue(Context.configDisplayName, event.username, true, ObjectType.String);
+    config.setValue(Context.configSelfStatus, event.status, true, ObjectType.String);
+    var avatarPath = event.avatarPath;
+    config.setValue(Context.configSelfAvatar, avatarPath, true, ObjectType.String);
     dispatch(UserChanged(config: config));
   }
 
   void _saveUserAccountData(UserAccountDataChanged event) {
     Config config = Config();
-    config.setValue(Context.configMailUser, event.imapLogin, true);
-    config.setValue(Context.configMailPassword, event.imapPassword, true);
-    config.setValue(Context.configMailServer, event.imapServer, true);
-    config.setValue(Context.configMailPort, event.imapPort, true);
-    config.setValue(Context.configSendUser, event.smtpLogin, true);
-    config.setValue(Context.configSendPassword, event.smtpPassword, true);
-    config.setValue(Context.configSendServer, event.smtpServer, true);
-    config.setValue(Context.configSendPort, event.smtpPort, true);
+    config.setValue(Context.configMailUser, event.imapLogin, true, ObjectType.String);
+    config.setValue(Context.configMailPassword, event.imapPassword, true, ObjectType.String);
+    config.setValue(Context.configMailServer, event.imapServer, true, ObjectType.String);
+    config.setValue(Context.configMailPort, event.imapPort, true, ObjectType.int);
+    config.setValue(Context.configSendUser, event.smtpLogin, true, ObjectType.String);
+    config.setValue(Context.configSendPassword, event.smtpPassword, true, ObjectType.String);
+    config.setValue(Context.configSendServer, event.smtpServer, true, ObjectType.String);
+    config.setValue(Context.configSendPort, event.smtpPort, true, ObjectType.int);
     dispatch(UserChanged(config: config));
   }
 }

--- a/lib/source/utils/widget.dart
+++ b/lib/source/utils/widget.dart
@@ -42,6 +42,14 @@
 
 import 'package:flutter/material.dart';
 
+Key createKey(var value) {
+  if (value is String) {
+    return Key(value);
+  } else {
+    return Key(value.toString());
+  }
+}
+
 OutlineButton buildOutlineButton({
   BuildContext context,
   Function onPressed,
@@ -57,7 +65,7 @@ OutlineButton buildOutlineButton({
   );
 }
 
-Widget getTextOrPlaceHolder({
+Widget buildTextOrPlaceHolder({
   @required String text,
   TextStyle style,
   TextAlign align,


### PR DESCRIPTION
- Allowing null values for config values if a specific type is given
- Added image_picker and image_cropper
- Added a UI to choose between camera, gallery and resetting of the set avatar image
- Cleanups and smaller adjustments

I used async requests in a Flutter widget. This is intentional and I will adjust the documentation accordingly. We should never load data from the DCC via async events in Flutter widgets, but if a call to a plugin or something similar is made, which ONLY affects UI states, it's okay to use those calls. More or less the same logic applies as for the calling of setState.