### PR TITLE
OT-120 Broken contact list after contact edit #12

### DIFF
--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -105,6 +105,8 @@ class _ContactChangeState extends State<ContactChange> {
         textFormType: TextFormType.email,
         inputType: TextInputType.emailAddress,
       );
+    } else {
+      _nameField.controller.text = widget.name != null ? widget.name : "";
     }
     final contactAddedObservable = new Observable<ContactChangeState>(_contactChangeBloc.state);
     contactAddedObservable.listen((state) => handleContactChanged(state));
@@ -144,7 +146,6 @@ class _ContactChangeState extends State<ContactChange> {
       changeToast = AppLocalizations.of(context).contactChangeEditToast;
       deleteToast = AppLocalizations.of(context).contactChangeDeleteToast;
       deleteFailedToast = AppLocalizations.of(context).contactChangeDeleteFailedToast;
-      _nameField.controller.text = widget.name != null ? widget.name : "";
     }
     return Scaffold(
         appBar: AppBar(

--- a/lib/src/contact/contact_list_bloc.dart
+++ b/lib/src/contact/contact_list_bloc.dart
@@ -70,12 +70,10 @@ class ContactListBloc extends Bloc<ContactListEvent, ContactListState> {
     } else if (event is ContactsChanged) {
       List<int> resultValidContactIds = List();
       List<int> resultValidContactLastUpdateValues = List();
-      for (int index = 0; index < contactRepository.getAllIds().length; index++) {
-        var contact = contactRepository.get(index);
-        if (validContactIds.contains(contact.getId())) {
-          resultValidContactIds.add(contact.getId());
-          resultValidContactLastUpdateValues.add(contact.lastUpdate);
-        }
+      for (int index = 0; index < validContactIds.length; index++) {
+        var contact = contactRepository.get(validContactIds[index]);
+        resultValidContactIds.add(contact.getId());
+        resultValidContactLastUpdateValues.add(contact.lastUpdate);
       }
       yield ContactListStateSuccess(contactIds: resultValidContactIds, contactLastUpdateValues: resultValidContactLastUpdateValues);
     }
@@ -93,14 +91,18 @@ class ContactListBloc extends Bloc<ContactListEvent, ContactListState> {
     streamSubscription = contactRepository.observable.listen((event) => dispatchContactsChanged());
   }
 
-  void dispatchContactsChanged() {
-    validContactIds = contactRepository.getAllIds();
+  void dispatchContactsChanged() async {
+    await _updateValidContactIds();
     dispatch(ContactsChanged());
   }
 
-  void setupContacts() async {
+  Future _updateValidContactIds() async {
     Context _context = Context();
     validContactIds = List.from(await _context.getContacts(2, null));
+  }
+
+  void setupContacts() async {
+    await _updateValidContactIds();
     contactRepository.putIfAbsent(ids: validContactIds);
     dispatch(ContactsChanged());
   }

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -69,11 +69,11 @@ class AppLocalizations {
   //translation complete
 
   // No translation
-  String get sslTls => "SSL/TLS";
-  String get startTLS => "StartTLS";
+  String get sslTls => 'SSL/TLS';
+  String get startTLS => 'StartTLS';
 
   // No translation + DCC default values which should get adjusted
-  String get deltaChatStatusDefaultValue => "Sent with my Delta Chat Messenger: https://delta.chat";
+  String get deltaChatStatusDefaultValue => 'Sent with my Delta Chat Messenger: https://delta.chat';
 
   // Global
   String get yes => Intl.message('Yes', name: 'yes');
@@ -146,8 +146,8 @@ class AppLocalizations {
   String get contactChangeDeleteTitle => Intl.message('Delete Contact', name: 'contactChangeDeleteTitle');
   String get contactChangeDeleteToast => Intl.message('Contact successfully deleted', name: 'contactChangeDeleteToast');
   String get contactChangeDeleteFailedToast => Intl.message('Could not delete contact.', name: 'contactChangeDeleteFailedToast');
-  String contactChangeDeleteDialogContent(email, name) => Intl.message('"Do you really want to delete $email ($name)?', name: 'contactChangeDeleteDialogContent', args: [email, name]);
-  String get contactChangeNameHint => Intl.message('"Enter the contact name"', name: 'contactChangeNameHint');
+  String contactChangeDeleteDialogContent(email, name) => Intl.message('Do you really want to delete $email ($name)?', name: 'contactChangeDeleteDialogContent', args: [email, name]);
+  String get contactChangeNameHint => Intl.message('Enter the contact name', name: 'contactChangeNameHint');
 
   String get contactImportDialogTitle => Intl.message('Import system contacts', name: 'contactImportDialogTitle');
   String get contactImportDialogContent => Intl.message('Would you like to import your system contacts?', name: 'contactImportDialogContent');


### PR DESCRIPTION
**Link to the given issue**
#12 

**Describe what the problem was / what the new feature is**
The contacts aren't correctly sorted and are broken after an update (e.g. change a name).

**Describe your solution**
- Our getAllIds logic after an update was simply wrong, we need to get the list directly from the DCC
- We just need to iterate over the valid contacts instead of the complex solution (which also breaks the sorting done by the DCC) we applied before
- Also fixed some translations issues
- Also fixed a jumpy cursor in the ChangeContact view

**Additional context**
None
