### PR TITLE
OT-92 #9 IMAP and SMTP security setting is not used

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,14 +48,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:ox_talk/src/data/config.dart';
 import 'package:ox_talk/src/log/bloc_delegate.dart';
-import 'package:ox_talk/src/chat/create_chat.dart';
-import 'package:ox_talk/src/contact/contact_change.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/login/login.dart';
 import 'package:ox_talk/src/main/root.dart';
 import 'package:ox_talk/src/main/splash.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
-import 'package:ox_talk/src/profile/edit_account_settings.dart';
 
 void main() {
   BlocSupervisor().delegate = DebugBlocDelegate();

--- a/lib/src/chat/create_chat.dart
+++ b/lib/src/chat/create_chat.dart
@@ -74,7 +74,7 @@ class _CreateChatState extends State<CreateChat> {
         appBar: AppBar(
           leading: new IconButton(
             icon: new Icon(Icons.close),
-            onPressed: () => navigation.pop(context),
+            onPressed: () => navigation.pop(context, "CreateChat"),
           ),
           backgroundColor: chatMain,
           title: Text(AppLocalizations.of(context).createChatTitle),
@@ -136,17 +136,19 @@ class _CreateChatState extends State<CreateChat> {
     navigation.push(
       context,
       MaterialPageRoute(
-        builder: (context) => ContactChange(contactAction: ContactAction.add, createChat: true,)
-      )
+        builder: (context) => ContactChange(contactAction: ContactAction.add, createChat: true,),
+      ),
+      "ContactChange"
     );
   }
 
   createGroupTapped() {
     navigation.push(
-        context,
-        MaterialPageRoute(
-            builder: (context) => CreateGroupChat()
-        )
+      context,
+      MaterialPageRoute(
+        builder: (context) => CreateGroupChat(),
+      ),
+      "CreateGroupChat"
     );
   }
 }

--- a/lib/src/chat/create_group_chat.dart
+++ b/lib/src/chat/create_group_chat.dart
@@ -43,7 +43,6 @@
 import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ox_talk/main.dart';
 import 'package:ox_talk/src/chat/chat.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
@@ -82,7 +81,7 @@ class _CreateGroupChatState extends State<CreateGroupChat> {
         appBar: AppBar(
           leading: new IconButton(
             icon: new Icon(Icons.close),
-            onPressed: () => navigation.pop(context),
+            onPressed: () => navigation.pop(context, "CreateGroupChat"),
           ),
           backgroundColor: chatMain,
           title: Text(AppLocalizations.of(context).createGroupTitle),
@@ -163,7 +162,12 @@ class _CreateGroupChatState extends State<CreateGroupChat> {
         coreContext.addContactToChat(chatId, selectedItems[i]);
       }
       chatRepository.putIfAbsent(id: chatId);
-      navigation.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context) => ChatScreen(chatId)), ModalRoute.withName(Navigation.ROUTES_ROOT));
+      navigation.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(builder: (context) => ChatScreen(chatId), settings: RouteSettings(name: "ChatScreen")),
+        ModalRoute.withName(Navigation.ROUTES_ROOT),
+        "ChatScreen"
+      );
     }
   }
 }

--- a/lib/src/chatlist/chat_list.dart
+++ b/lib/src/chatlist/chat_list.dart
@@ -42,7 +42,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ox_talk/main.dart';
 import 'package:ox_talk/src/base/base_root_child.dart';
 import 'package:ox_talk/src/chatlist/chat_list_bloc.dart';
 import 'package:ox_talk/src/chatlist/chat_list_event.dart';

--- a/lib/src/chatlist/chat_list_invite_item.dart
+++ b/lib/src/chatlist/chat_list_invite_item.dart
@@ -120,21 +120,21 @@ class _ChatListInviteItemState extends State<ChatListInviteItem> {
               new FlatButton(
                 child: new Text(AppLocalizations.of(context).cancel),
                 onPressed: () {
-                  navigation.pop(context);
+                  navigation.pop(context, "InviteItemTappedDialog");
                 },
               ),
               new FlatButton(
                 child: new Text(AppLocalizations.of(context).block),
                 onPressed: () {
                   blockUser();
-                  navigation.pop(context);
+                  navigation.pop(context, "InviteItemTappedDialog");
                 },
               ),
               new FlatButton(
                 child: new Text(AppLocalizations.of(context).yes),
                 onPressed: () {
                   createChat();
-                  navigation.pop(context);
+                  navigation.pop(context, "InviteItemTappedDialog");
                 },
               ),
             ],
@@ -151,7 +151,7 @@ class _ChatListInviteItemState extends State<ChatListInviteItem> {
 
   _handleChangeChatStateChange(ChangeChatState state) {
     if (state is CreateChatStateSuccess) {
-      navigation.push(context, MaterialPageRoute(builder: (context) => ChatScreen(state.chatId)));
+      navigation.push(context, MaterialPageRoute(builder: (context) => ChatScreen(state.chatId)), "ChatListInviteItem");
     }
   }
 

--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -119,13 +119,13 @@ class _ContactChangeState extends State<ContactChange> {
         } else {
           showToast(changeToast);
         }
-        navigation.pop(context);
+        navigation.pop(context, "ContactChanged");
       } else {
         if (state.id != null) {
           Context coreContext = Context();
           var chatId = await coreContext.createChatByContactId(state.id);
           chatRepository.putIfAbsent(id: chatId);
-          navigation.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context) => ChatScreen(chatId)), ModalRoute.withName(Navigation.ROUTES_ROOT));
+          navigation.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context) => ChatScreen(chatId)), ModalRoute.withName(Navigation.ROUTES_ROOT), "ChatScreen");
         }
       }
     } else if (state is ContactChangeStateFailure && state.error == contactDelete) {
@@ -150,7 +150,7 @@ class _ContactChangeState extends State<ContactChange> {
         appBar: AppBar(
           leading: new IconButton(
             icon: new Icon(Icons.close),
-            onPressed: () => navigation.pop(context),
+            onPressed: () => navigation.pop(context, "ContactChange"),
           ),
           backgroundColor: contactMain,
           title: Text(title),
@@ -252,14 +252,14 @@ class _ContactChangeState extends State<ContactChange> {
               new FlatButton(
                 child: new Text(AppLocalizations.of(context).no),
                 onPressed: () {
-                  navigation.pop(context);
+                  navigation.pop(context, "ContactChange");
                 },
               ),
               new FlatButton(
                 child: new Text(AppLocalizations.of(context).delete),
                 onPressed: () {
                   _contactChangeBloc.dispatch(DeleteContact(widget.id));
-                  navigation.pop(context);
+                  navigation.pop(context, "ContactChange");
                 },
               ),
             ],

--- a/lib/src/contact/contact_item.dart
+++ b/lib/src/contact/contact_item.dart
@@ -50,9 +50,7 @@ import 'package:ox_talk/src/contact/contact_item_bloc.dart';
 import 'package:ox_talk/src/contact/contact_item_event.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/contact/contact_item_builder_mixin.dart';
-import 'package:ox_talk/src/contact/contact_item_state.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
-import 'package:ox_talk/src/widgets/avatar_list_item.dart';
 import 'package:rxdart/rxdart.dart';
 
 class ContactItem extends StatefulWidget {
@@ -92,6 +90,7 @@ class _ContactItemState extends State<ContactItem> with ContactItemBuilder {
                   email: email,
                   name: name,
                 )),
+        "ContactChange"
       );
     } else {
       return buildCreateChatDialog(name, email);
@@ -140,7 +139,7 @@ class _ContactItemState extends State<ContactItem> with ContactItemBuilder {
 
   _handleCreateChatStateChange(ChangeChatState state) {
     if (state is CreateChatStateSuccess) {
-      navigation.pushReplacement(context, MaterialPageRoute(builder: (context) => ChatScreen(state.chatId)));
+      navigation.pushReplacement(context, MaterialPageRoute(builder: (context) => ChatScreen(state.chatId)), "ChatScreen");
     }
   }
 }

--- a/lib/src/contact/contact_list.dart
+++ b/lib/src/contact/contact_list.dart
@@ -42,7 +42,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ox_talk/main.dart';
 import 'package:ox_talk/src/base/base_root_child.dart';
 import 'package:ox_talk/src/contact/contact_import_bloc.dart';
 import 'package:ox_talk/src/contact/contact_import_event.dart';
@@ -60,7 +59,7 @@ import 'package:ox_talk/src/navigation/navigation.dart';
 import 'package:rxdart/rxdart.dart';
 
 class ContactListView extends BaseRootChild {
-  Navigation navigation = Navigation();
+  final Navigation navigation = Navigation();
 
   @override
   _ContactListState createState() {

--- a/lib/src/data/config.dart
+++ b/lib/src/data/config.dart
@@ -41,6 +41,7 @@
  */
 
 import 'package:delta_chat_core/delta_chat_core.dart';
+import 'package:ox_talk/src/utils/protocol_security_converter.dart';
 
 class Config {
   static Config _instance;
@@ -54,9 +55,11 @@ class Config {
   String imapLogin;
   String imapServer;
   int imapPort;
+  int imapSecurity;
   String smtpLogin;
   String smtpServer;
   int smtpPort;
+  int smtpSecurity;
 
   int get lastUpdate => _lastUpdate;
 
@@ -83,6 +86,10 @@ class Config {
     smtpLogin = await _context.getConfigValue(Context.configSendUser);
     smtpServer = await _context.getConfigValue(Context.configSendServer);
     smtpPort = await _context.getConfigValue(Context.configSendPort, ObjectType.int);
+    int serverFlags = await _context.getConfigValue(Context.configServerFlags, ObjectType.int);
+    imapSecurity = getSavedImapSecurityOption(serverFlags);
+    smtpSecurity = getSavedSmtpSecurityOption(serverFlags);
+    
     setLastUpdate();
   }
 
@@ -137,6 +144,18 @@ class Config {
       case Context.configSendPort:
         smtpPort = value;
         break;
+      case Context.configServerFlags:
+        int sel = 0;
+        if((value & Context.serverFlagsImapSsl) != 0) sel = 1;
+        if((value & Context.serverFlagsImapStartTls) != 0) sel = 2;
+        if((value & Context.serverFlagsImapPlain) !=0 ) sel = 3;
+        imapSecurity = sel;
+
+        sel = 0;
+        if((value & Context.serverFlagsSmtpSsl) != 0) sel = 1;
+        if((value & Context.serverFlagsSmtpStartTls) != 0) sel = 2;
+        if((value & Context.serverFlagsSmtpPlain) != 0) sel = 3;
+        smtpSecurity = sel;
     }
     if (enforceType != null) {
       _context.setConfigValue(key, value, enforceType);
@@ -146,7 +165,7 @@ class Config {
     setLastUpdate();
   }
 
-  String get smtpPortAsString => smtpPort > 0 ? smtpPort : "";
+  String get smtpPortAsString => smtpPort != null ? (smtpPort > 0 ? smtpPort.toString() : "") : null;
 
-  String get imapPortAsString => imapPort > 0 ? imapPort : "";
+  String get imapPortAsString => imapPort != null ? (imapPort > 0 ? imapPort.toString() : "") : null;
 }

--- a/lib/src/login/login.dart
+++ b/lib/src/login/login.dart
@@ -48,6 +48,7 @@ import 'package:ox_talk/src/login/login_state.dart';
 import 'package:ox_talk/src/utils/colors.dart';
 import 'package:ox_talk/src/utils/dimensions.dart';
 import 'package:ox_talk/src/utils/styles.dart';
+import 'package:ox_talk/src/utils/protocol_security_converter.dart';
 import 'package:ox_talk/src/widgets/progress_handler.dart';
 import 'package:ox_talk/src/widgets/validatable_text_form_field.dart';
 import 'package:rxdart/rxdart.dart';
@@ -128,10 +129,12 @@ class _LoginState extends State<Login> {
     var imapLogin = imapLoginNameField.controller.text;
     var imapServer = imapServerField.controller.text;
     var imapPort = imapPortField.controller.text;
+    var imapSecurity = convertProtocolStringToInt(context, _selectedImapSecurity);
     var smtpLogin = smtpLoginNameField.controller.text;
     var smtpPassword = smtpPasswordField.controller.text;
     var smtpServer = smtpServerField.controller.text;
     var smtpPort = smtpPortField.controller.text;
+    var smtpSecurity = convertProtocolStringToInt(context, _selectedSmtpSecurity);
 
     bool simpleLoginIsValid = _simpleLoginKey.currentState.validate();
     bool advancedLoginIsValid = _advancedLoginKey.currentState != null ? _advancedLoginKey.currentState.validate() : true;
@@ -148,10 +151,12 @@ class _LoginState extends State<Login> {
         imapLogin: imapLogin,
         imapServer: imapServer,
         imapPort: imapPort.isNotEmpty ? int.parse(imapPort) : null,
+        imapSecurity: imapSecurity,
         smtpLogin: smtpLogin,
         smtpPassword: smtpPassword,
         smtpServer: smtpServer,
         smtpPort: smtpPort.isNotEmpty ? int.parse(smtpPort) : null,
+        smtpSecurity: smtpSecurity,
       ));
     }
   }
@@ -224,7 +229,7 @@ class _LoginState extends State<Login> {
               Padding(padding: EdgeInsets.only(top: formVerticalPadding)),
               Text(AppLocalizations.of(context).loginLabelImapSecurity),
               DropdownButton(
-                  value: _selectedImapSecurity,
+                  value: _selectedImapSecurity == null ? AppLocalizations.of(context).automatic : _selectedImapSecurity,
                   items: getSecurityOptions(),
                   onChanged: (String newValue) {
                     setState(() {
@@ -240,7 +245,7 @@ class _LoginState extends State<Login> {
               Padding(padding: EdgeInsets.only(top: formVerticalPadding)),
               Text(AppLocalizations.of(context).loginLabelSmtpSecurity),
               DropdownButton(
-                  value: _selectedSmtpSecurity,
+                  value: _selectedSmtpSecurity == null ? AppLocalizations.of(context).automatic : _selectedSmtpSecurity,
                   items: getSecurityOptions(),
                   onChanged: (String newValue) {
                     setState(() {

--- a/lib/src/login/login_bloc.dart
+++ b/lib/src/login/login_bloc.dart
@@ -47,6 +47,7 @@ import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:ox_talk/src/data/config.dart';
 import 'package:ox_talk/src/login/login_events.dart';
 import 'package:ox_talk/src/login/login_state.dart';
+import 'package:ox_talk/src/utils/protocol_security_converter.dart';
 
 class LoginBloc extends Bloc<LoginEvent, LoginState> {
   DeltaChatCore _core = DeltaChatCore();
@@ -95,6 +96,11 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     config.setValue(Context.configSendPassword, event.smtpPassword);
     config.setValue(Context.configSendServer, event.smtpServer);
     config.setValue(Context.configSendPort, event.smtpPort);
+    int imapSecurity = event.imapSecurity;
+    int smtpSecurity = event.smtpSecurity;
+    int serverFlags = createServerFlagInteger(imapSecurity, smtpSecurity);
+
+    config.setValue(Context.configServerFlags, serverFlags, false, ObjectType.int);
   }
 
   void _updateConfig() {

--- a/lib/src/login/login_events.dart
+++ b/lib/src/login/login_events.dart
@@ -50,10 +50,12 @@ class LoginButtonPressed extends LoginEvent {
   final String imapLogin;
   final String imapServer;
   final int imapPort;
+  final int imapSecurity;
   final String smtpLogin;
   final String smtpPassword;
   final String smtpServer;
   final int smtpPort;
+  final int smtpSecurity;
 
   LoginButtonPressed(
       {@required this.email,
@@ -61,10 +63,12 @@ class LoginButtonPressed extends LoginEvent {
       @required this.imapLogin,
       @required this.imapServer,
       @required this.imapPort,
+      @required this.imapSecurity,
       @required this.smtpLogin,
       @required this.smtpPassword,
       @required this.smtpServer,
-      @required this.smtpPort});
+      @required this.smtpPort,
+      @required this.smtpSecurity});
 }
 
 class LoginProgress extends LoginEvent {

--- a/lib/src/navigation/navigation.dart
+++ b/lib/src/navigation/navigation.dart
@@ -67,8 +67,8 @@ class Navigation{
     ROUTES_CHAT_CREATE: (context) => CreateChat(),
   };
 
-  void push(BuildContext context, MaterialPageRoute route) {
-    debugPrint("Navigation.push");
+  void push(BuildContext context, MaterialPageRoute route, String routeToPage) {
+    debugPrint("Navigation.push to $routeToPage");
     Navigator.push(context, route);
   }
 
@@ -77,18 +77,18 @@ class Navigation{
     Navigator.pushNamed(context, routeName, arguments: arguments);
   }
 
-  void pop(BuildContext context){
-    debugPrint("Navigation.pop");
+  void pop(BuildContext context, String popFromPage){
+    debugPrint("Navigation.pop from $popFromPage");
     Navigator.pop(context);
   }
 
-  void pushAndRemoveUntil(BuildContext context, Route newRoute, RoutePredicate predicate) {
-    debugPrint("Navigation.pushAndRemoveUntil to $newRoute until $predicate");
+  void pushAndRemoveUntil(BuildContext context, Route newRoute, RoutePredicate predicate, String routeToPage) {
+    debugPrint("Navigation.pushAndRemoveUntil to $routeToPage until $predicate");
     Navigator.pushAndRemoveUntil(context, newRoute, predicate);
   }
 
-  void pushReplacement(BuildContext context, Route newRoute) {
-    debugPrint("Navigation.pushReplacement");
+  void pushReplacement(BuildContext context, Route newRoute, String routeToPage) {
+    debugPrint("Navigation.pushReplacement to $routeToPage");
     Navigator.pushReplacement(context, newRoute);
   }
 }

--- a/lib/src/profile/edit_account_settings.dart
+++ b/lib/src/profile/edit_account_settings.dart
@@ -53,6 +53,7 @@ import 'package:ox_talk/src/profile/user_state.dart';
 import 'package:ox_talk/src/utils/colors.dart';
 import 'package:ox_talk/src/utils/dimensions.dart';
 import 'package:ox_talk/src/utils/toast.dart';
+import 'package:ox_talk/src/utils/protocol_security_converter.dart';
 import 'package:rxdart/rxdart.dart';
 
 class EditAccountSettings extends StatefulWidget {
@@ -112,7 +113,7 @@ class _EditAccountSettingsState extends State<EditAccountSettings> {
         appBar: AppBar(
           leading: new IconButton(
             icon: new Icon(Icons.close),
-            onPressed: () => navigation.pop(context),
+            onPressed: () => navigation.pop(context, "EditAccountSettings"),
           ),
           backgroundColor: contactMain,
           title: Text(AppLocalizations.of(context).editAccountSettingsTitle),
@@ -139,6 +140,8 @@ class _EditAccountSettingsState extends State<EditAccountSettings> {
     smtpLoginNameField.controller.text = config.smtpLogin;
     smtpServerField.controller.text = config.imapServer;
     smtpPortField.controller.text = config.smtpPortAsString;
+    _selectedImapSecurity = convertProtocolIntToString(context, config.imapSecurity);
+    _selectedSmtpSecurity = convertProtocolIntToString(context, config.smtpSecurity);
   }
 
   Widget _buildEditAccountDataView() {
@@ -194,21 +197,26 @@ class _EditAccountSettingsState extends State<EditAccountSettings> {
       var imapPassword = imapPasswordField.controller.text;
       var imapServer = imapServerField.controller.text;
       var imapPort = imapPortField.controller.text;
+      var imapSecurity = convertProtocolStringToInt(context, _selectedImapSecurity);
       var smtpLogin = smtpLoginNameField.controller.text;
       var smtpPassword = smtpPasswordField.controller.text;
       var smtpServer = smtpServerField.controller.text;
       var smtpPort = smtpPortField.controller.text;
+      var smtpSecurity = convertProtocolStringToInt(context, _selectedSmtpSecurity);
+
       _userBloc.dispatch(UserAccountDataChanged(
         imapLogin: imapLogin,
         imapPassword: imapPassword,
         imapServer: imapServer,
         imapPort: imapPort.isNotEmpty ? int.parse(imapPort) : null,
+        imapSecurity: imapSecurity,
         smtpLogin: smtpLogin,
         smtpPassword: smtpPassword,
         smtpServer: smtpServer,
         smtpPort: smtpPort.isNotEmpty ? int.parse(smtpPort) : null,
+        smtpSecurity:smtpSecurity,
       ));
-      navigation.pop(context);
+      navigation.pop(context, "EditAccountSettings");
     }
   }
 

--- a/lib/src/profile/edit_user_settings.dart
+++ b/lib/src/profile/edit_user_settings.dart
@@ -96,7 +96,7 @@ class _EditUserSettingsState extends State<EditUserSettings> with TickerProvider
         appBar: AppBar(
           leading: new IconButton(
             icon: new Icon(Icons.close),
-            onPressed: () => navigation.pop(context),
+            onPressed: () => navigation.pop(context, "EditUserSettings"),
           ),
           backgroundColor: contactMain,
           title: Text(AppLocalizations.of(context).editUserSettingsTitle),
@@ -204,7 +204,7 @@ class _EditUserSettingsState extends State<EditUserSettings> with TickerProvider
   }
 
   _getNewAvatarPath(ImageSource source) async {
-    navigation.pop(context);
+    navigation.pop(context, "EditUserSettings - ModalBottomSheet");
     File newAvatar = await ImagePicker.pickImage(source: source);
     if (newAvatar != null) {
       File croppedAvatar = await ImageCropper.cropImage(
@@ -223,7 +223,7 @@ class _EditUserSettingsState extends State<EditUserSettings> with TickerProvider
   }
 
   _removeAvatar() {
-    navigation.pop(context);
+    navigation.pop(context, "EditUserSettings - ModalBottomSheet");
     setState(() {
       _avatar = null;
     });
@@ -232,6 +232,6 @@ class _EditUserSettingsState extends State<EditUserSettings> with TickerProvider
   void _saveChanges() async {
     String avatarPath = _avatar != null ? _avatar.path : null;
     _userBloc.dispatch(UserPersonalDataChanged(username: _usernameController.text, status: _statusController.text, avatarPath: avatarPath));
-    navigation.pop(context);
+    navigation.pop(context, "EditUserSettings");
   }
 }

--- a/lib/src/profile/profile.dart
+++ b/lib/src/profile/profile.dart
@@ -44,7 +44,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ox_talk/main.dart';
 import 'package:ox_talk/src/base/base_root_child.dart';
 import 'package:ox_talk/src/data/config.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
@@ -198,6 +197,7 @@ class _ProfileState extends State<ProfileView> {
     navigation.push(
       context,
       MaterialPageRoute(builder: (context) => EditUserSettings()),
+      "EditUserSettings"
     );
   }
 }

--- a/lib/src/profile/user_bloc.dart
+++ b/lib/src/profile/user_bloc.dart
@@ -47,6 +47,7 @@ import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:ox_talk/src/data/config.dart';
 import 'package:ox_talk/src/profile/user_event.dart';
 import 'package:ox_talk/src/profile/user_state.dart';
+import 'package:ox_talk/src/utils/protocol_security_converter.dart';
 
 class UserBloc extends Bloc<UserEvent, UserState> {
   @override
@@ -100,11 +101,16 @@ class UserBloc extends Bloc<UserEvent, UserState> {
     config.setValue(Context.configMailUser, event.imapLogin, true, ObjectType.String);
     config.setValue(Context.configMailPassword, event.imapPassword, true, ObjectType.String);
     config.setValue(Context.configMailServer, event.imapServer, true, ObjectType.String);
-    config.setValue(Context.configMailPort, event.imapPort, true, ObjectType.int);
+    config.setValue(Context.configMailPort, event.imapPort, true, ObjectType.String);
     config.setValue(Context.configSendUser, event.smtpLogin, true, ObjectType.String);
     config.setValue(Context.configSendPassword, event.smtpPassword, true, ObjectType.String);
     config.setValue(Context.configSendServer, event.smtpServer, true, ObjectType.String);
-    config.setValue(Context.configSendPort, event.smtpPort, true, ObjectType.int);
+    config.setValue(Context.configSendPort, event.smtpPort, true, ObjectType.String);
+    int imapSecurity = event.imapSecurity;
+    int smtpSecurity = event.smtpSecurity;
+    int serverFlags = createServerFlagInteger(imapSecurity, smtpSecurity);
+
+    config.setValue(Context.configServerFlags, serverFlags, false, ObjectType.int);
     dispatch(UserChanged(config: config));
   }
 }

--- a/lib/src/profile/user_event.dart
+++ b/lib/src/profile/user_event.dart
@@ -66,20 +66,24 @@ class UserAccountDataChanged extends UserEvent {
   final String imapPassword;
   final String imapServer;
   final int imapPort;
+  final int imapSecurity;
   final String smtpLogin;
   final String smtpPassword;
   final String smtpServer;
   final int smtpPort;
+  final int smtpSecurity;
 
   UserAccountDataChanged(
       {@required this.imapLogin,
       @required this.imapPassword,
       @required this.imapServer,
       @required this.imapPort,
+      @required this.imapSecurity,
       @required this.smtpLogin,
       @required this.smtpPassword,
       @required this.smtpServer,
-      @required this.smtpPort});
+      @required this.smtpPort,
+      @required this.smtpSecurity,});
 }
 
 class UserChanged extends UserEvent {

--- a/lib/src/utils/protocol_security_converter.dart
+++ b/lib/src/utils/protocol_security_converter.dart
@@ -40,73 +40,52 @@
  * for more details.
  */
 
+import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ox_talk/src/chat/chat.dart';
-import 'package:ox_talk/src/chat/chat_bloc.dart';
-import 'package:ox_talk/src/chat/chat_event.dart';
-import 'package:ox_talk/src/chat/chat_state.dart';
-import 'package:ox_talk/src/utils/dimensions.dart';
-import 'package:ox_talk/src/navigation/navigation.dart';
-import 'package:ox_talk/src/widgets/avatar_list_item.dart';
+import 'package:ox_talk/src/l10n/localizations.dart';
 
-class ChatListItem extends StatefulWidget {
-  final int _chatId;
+enum ProtocolType{imap,smtp}
 
-  ChatListItem(this._chatId, key) : super(key: Key(key));
-
-  @override
-  _ChatListItemState createState() => _ChatListItemState();
+int convertProtocolStringToInt(BuildContext context, String value){
+  int newValue = 0;
+  if(value == AppLocalizations.of(context).sslTls) newValue = 1;
+  else if(value == AppLocalizations.of(context).startTLS) newValue = 2;
+  else if(value == AppLocalizations.of(context).off) newValue = 3;
+  return newValue;
 }
 
-class _ChatListItemState extends State<ChatListItem> {
-  ChatBloc _chatBloc = ChatBloc();
-  Navigation navigation = Navigation();
+String convertProtocolIntToString(BuildContext context, int value) {
+  String newValue;
+  if(value == 1) newValue = AppLocalizations.of(context).sslTls;
+  else if(value == 2) newValue = AppLocalizations.of(context).startTLS;
+  else if(value == 3) newValue = AppLocalizations.of(context).off;
+  else newValue = AppLocalizations.of(context).automatic;
+  return newValue;
+}
 
-  @override
-  void initState() {
-    super.initState();
-    _chatBloc.dispatch(RequestChat(widget._chatId));
-  }
+int getSavedImapSecurityOption(int serverFlags){
+  int sel = 0;
+  if((serverFlags & Context.serverFlagsImapSsl) != 0) sel = 1;
+  if((serverFlags & Context.serverFlagsImapStartTls) != 0) sel = 2;
+  if((serverFlags & Context.serverFlagsImapPlain) !=0 ) sel = 3;
+  return sel;
+}
 
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder(
-      bloc: _chatBloc,
-      builder: (context, state) {
-        String name;
-        String subTitle;
-        Color color;
-        if (state is ChatStateSuccess) {
-          name = state.name;
-          subTitle = state.subTitle;
-          color = state.color;
-        } else {
-          name = "";
-          subTitle = "";
-        }
-        return AvatarListItem(
-          title: name,
-          subTitle: subTitle,
-          color: color,
-          subTitleIcon: _chatBloc.isGroup
-              ? Icon(
-                  Icons.group,
-                  size: iconSize,
-                )
-              : Container(),
-          onTap: chatItemTapped,
-        );
-      },
-    );
-    /*;*/
-  }
+int getSavedSmtpSecurityOption(int serverFlags){
+  int sel = 0;
+  if((serverFlags & Context.serverFlagsSmtpSsl) != 0) sel = 1;
+  if((serverFlags & Context.serverFlagsSmtpStartTls) != 0) sel = 2;
+  if((serverFlags & Context.serverFlagsSmtpPlain) != 0) sel = 3;
+  return sel;
+}
 
-  chatItemTapped(String name, String subtitle) {
-    navigation.push(
-      context,
-      MaterialPageRoute(builder: (context) => ChatScreen(widget._chatId),),
-      "ChatScreen"
-    );
-  }
+int createServerFlagInteger(int imapOption, int smtpOption){
+  int serverFlags = 0;
+  if(imapOption == 1) serverFlags |= Context.serverFlagsImapSsl;
+  if(imapOption == 2) serverFlags |= Context.serverFlagsImapStartTls;
+  if(imapOption == 3) serverFlags |= Context.serverFlagsImapPlain;
+  if(smtpOption == 1) serverFlags |= Context.serverFlagsSmtpSsl;
+  if(smtpOption == 2) serverFlags |= Context.serverFlagsSmtpStartTls;
+  if(smtpOption == 3) serverFlags |= Context.serverFlagsSmtpPlain;
+  return serverFlags;
 }

--- a/lib/src/widgets/dialog_builder.dart
+++ b/lib/src/widgets/dialog_builder.dart
@@ -67,14 +67,14 @@ class DialogBuilder {
                 if (negativeAction != null) {
                   negativeAction();
                 }
-                navigation.pop(context);
+                navigation.pop(context, "DialogBuilder");
               },
             ),
             new FlatButton(
               child: new Text(positiveButton),
               onPressed: () {
                 positiveAction();
-                navigation.pop(context);
+                navigation.pop(context, "DialogBuilder");
               },
             ),
           ],


### PR DESCRIPTION
---
name: Pull request
about: Create a pull request to improve or extend the code
title: ''
labels: ''
assignees: ''

---

**Link to the given issue**
https://github.com/open-xchange/ox-talk/issues/9

**Describe what the problem was / what the new feature is**
The IMAP and SMTP security options were not saved.

**Describe your solution**
Now it is possible to save the protocol security options. I've  added a new utils class which handles the generation of the server flags and everything which is needed for the protocol security options.

**Additional context**
I also added a new parameter for the navigation methods to see which class is called.