### PR TITLE
OT-116 Add error handling for the login process #6

### DIFF
--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -104,6 +104,8 @@ class AppLocalizations {
 
   String get name => Intl.message('Name', name: 'name');
 
+  String get ok => Intl.message('Ok', name: 'ok');
+
   String get cancel => Intl.message('Cancel', name: 'cancel');
 
   String get block => Intl.message('Block', name: 'block');
@@ -114,42 +116,84 @@ class AppLocalizations {
 
   // Core
   String get coreChatNoMessages => Intl.message('No messages', name: 'coreChatNoMessages');
+
   String get coreSelf => Intl.message('Me', name: 'coreSelf');
+
   String get coreDraft => Intl.message('Draft', name: 'coreDraft');
+
   String get coreMembers => Intl.message('%1\$d member(s)', name: 'createChatWith');
+
   String get coreContacts => Intl.message('%1\$d contact(s)', name: 'createChatWith');
+
   String get coreVoiceMessage => Intl.message('Voice message', name: 'coreVoiceMessage');
+
   String get coreContactRequest => Intl.message('Contact request', name: 'coreContactRequest');
+
   String get coreImage => Intl.message('Image', name: 'coreImage');
+
   String get coreVideo => Intl.message('Video', name: 'coreVideo');
+
   String get coreAudio => Intl.message('Audio', name: 'coreAudio');
+
   String get coreFile => Intl.message('File', name: 'coreFile');
+
   String get coreGroupHelloDraft => Intl.message('Hello, I\'ve just created this group for us', name: 'coreGroupHelloDraft');
+
   String get coreGroupNameChanged => Intl.message('Group name changed', name: 'coreGroupNameChanged');
+
   String get coreGroupImageChanged => Intl.message('Group image changed', name: 'coreGroupImageChanged');
+
   String get coreGroupMemberAdded => Intl.message('Member added', name: 'coreGroupMemberAdded');
+
   String get coreGroupMemberRemoved => Intl.message('Member removed', name: 'coreGroupMemberRemoved');
+
   String get coreGroupLeft => Intl.message('Group left', name: 'coreGroupLeft');
+
   String get coreGenericError => Intl.message('Error: ', name: 'coreGenericError');
+
   String get coreGif => Intl.message('Gif', name: 'coreGif');
-  String get coreMessageCannotDecrypt => Intl.message('This message cannot be decrypted.\n\n'
+
+  String get coreMessageCannotDecrypt => Intl.message(
+      'This message cannot be decrypted.\n\n'
       '• It might already help to simply reply to this message and ask the sender to send the message again.\n\n'
-      '• In case you re-installed Delta Chat or another email program on this or another device you may want to send an Autocrypt Setup Message from there.', name: 'coreMessageCannotDecrypt');
+      '• In case you re-installed Delta Chat or another email program on this or another device you may want to send an Autocrypt Setup Message from there.',
+      name: 'coreMessageCannotDecrypt');
+
   String get coreReadReceiptSubject => Intl.message('Read receipt', name: 'coreReadReceiptSubject');
-  String get coreReadReceiptBody => Intl.message('This is a read receipt.\n\nIt means the message was displayed on the recipient\'s device, not necessarily that the content was read.', name: 'coreReadReceiptBody');
+
+  String get coreReadReceiptBody => Intl.message(
+      'This is a read receipt.\n\nIt means the message was displayed on the recipient\'s device, not necessarily that the content was read.',
+      name: 'coreReadReceiptBody');
+
   String get coreGroupImageDeleted => Intl.message('Group image deleted', name: 'coreGroupImageDeleted');
+
   String get coreContactVerified => Intl.message('Contact verified', name: 'coreContactVerified');
+
   String get coreContactNotVerified => Intl.message('Cannot verify contact', name: 'coreContactNotVerified');
+
   String get coreContactSetupChanged => Intl.message('Changed setup for contact', name: 'coreContactSetupChanged');
+
   String get coreArchivedChats => Intl.message('Archived chats', name: 'coreArchivedChats');
+
   String get coreAutoCryptSetupSubject => Intl.message('Autocrypt Setup Message', name: 'coreAutoCryptSetupSubject');
-  String get coreAutoCryptSetupBody => Intl.message('This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\n'
-      'To decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.', name: 'coreAutoCryptSetupBody');
+
+  String get coreAutoCryptSetupBody => Intl.message(
+      'This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\n'
+      'To decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.',
+      name: 'coreAutoCryptSetupBody');
+
   String get coreChatSelf => Intl.message('Messages I sent to myself', name: 'coreChatSelf');
-  String get coreLoginErrorCannotLogin => Intl.message('Cannot login. Please check if the email-address and the password are correct.', name: 'coreLoginErrorCannotLogin');
-  String get coreLoginErrorServerResponse => Intl.message('Response from %1\$s: %1\$2\n\n'
-      'Some providers place additional information in your inbox; you can check them it eg. in the web frontend. Consult your provider or friends if you run into problems.', name: 'coreLoginErrorServerResponse');
+
+  String get coreLoginErrorCannotLogin =>
+      Intl.message('Cannot login. Please check if the email-address and the password are correct.', name: 'coreLoginErrorCannotLogin');
+
+  String get coreLoginErrorServerResponse => Intl.message(
+      'Response from %1\$s: %1\$2\n\n'
+      'Some providers place additional information in your inbox; you can check them it eg. in the web frontend. Consult your provider or friends if you run into problems.',
+      name: 'coreLoginErrorServerResponse');
+
   String get coreActionByUser => Intl.message('%1\$s by %1\$2', name: 'coreActionByUser');
+
   String get coreActionByMe => Intl.message('%1\$s by me', name: 'coreActionByMe');
 
   // Form
@@ -197,13 +241,18 @@ class AppLocalizations {
 
   String get loginProgressMessage => Intl.message('Logging in, this may take a moment', name: 'loginProgressMessage');
 
+  String get loginErrorDialogTitle => Intl.message('Login failed', name: 'loginErrorDialogTitle');
+
   // Mail
   String get mailTitle => Intl.message('Mail', name: 'mailTitle');
 
   // Chat / chat list / invite list
   String get chatTitle => Intl.message('Chat', name: 'chatTitle');
+
   String get composePlaceholder => Intl.message('Type something...', name: 'composePlaceholder');
+
   String get inviteEmptyList => Intl.message('No invites', name: 'inviteEmptyList');
+
   String get chatListEmpty => Intl.message('No chats', name: 'chatListEmpty');
 
   // Create chat

--- a/lib/src/login/login.dart
+++ b/lib/src/login/login.dart
@@ -46,9 +46,10 @@ import 'package:ox_talk/src/login/login_bloc.dart';
 import 'package:ox_talk/src/login/login_events.dart';
 import 'package:ox_talk/src/login/login_state.dart';
 import 'package:ox_talk/src/utils/colors.dart';
+import 'package:ox_talk/src/utils/dialog_builder.dart';
 import 'package:ox_talk/src/utils/dimensions.dart';
-import 'package:ox_talk/src/utils/styles.dart';
 import 'package:ox_talk/src/utils/protocol_security_converter.dart';
+import 'package:ox_talk/src/utils/styles.dart';
 import 'package:ox_talk/src/widgets/progress_handler.dart';
 import 'package:ox_talk/src/widgets/validatable_text_form_field.dart';
 import 'package:rxdart/rxdart.dart';
@@ -96,6 +97,7 @@ class _LoginState extends State<Login> {
   String _selectedImapSecurity;
   String _selectedSmtpSecurity;
   bool _showAdvanced = false;
+  bool _showedErrorDialog = false;
   OverlayEntry _progressOverlayEntry;
   FullscreenProgress _progress;
 
@@ -115,6 +117,17 @@ class _LoginState extends State<Login> {
     }
     if (state is LoginStateSuccess) {
       widget._success();
+    } else if (state is LoginStateFailure) {
+      if (!_showedErrorDialog) {
+        _showedErrorDialog = true;
+        showInformationDialog(
+          context: context,
+          title: AppLocalizations
+              .of(context)
+              .loginErrorDialogTitle,
+          content: state.error,
+        );
+      }
     }
   }
 
@@ -147,7 +160,7 @@ class _LoginState extends State<Login> {
       _progressOverlayEntry = OverlayEntry(builder: (context) => _progress);
       OverlayState overlayState = Overlay.of(context);
       overlayState.insert(_progressOverlayEntry);
-
+      _showedErrorDialog = false;
       _loginBloc.dispatch(LoginButtonPressed(
         email: email,
         password: password,

--- a/lib/src/utils/dialog_builder.dart
+++ b/lib/src/utils/dialog_builder.dart
@@ -44,14 +44,15 @@ import 'package:flutter/material.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
 
-showConfirmationDialog(
-    {@required BuildContext context,
-    @required String title,
-    @required String content,
-    @required String positiveButton,
-    @required Function positiveAction,
-    String negativeButton,
-    Function negativeAction}) {
+showConfirmationDialog({
+  @required BuildContext context,
+  @required String title,
+  @required String content,
+  @required String positiveButton,
+  @required Function positiveAction,
+  String negativeButton,
+  Function negativeAction,
+}) {
   Navigation navigation = Navigation();
   return showDialog<void>(
     context: context,
@@ -66,14 +67,39 @@ showConfirmationDialog(
               if (negativeAction != null) {
                 negativeAction();
               }
-              navigation.pop(context, "DialogBuilder");
+              navigation.pop(context, "DialogBuilder.showConfirmationDialog");
             },
           ),
           new FlatButton(
             child: new Text(positiveButton),
             onPressed: () {
               positiveAction();
-              navigation.pop(context, "DialogBuilder");
+              navigation.pop(context, "DialogBuilder.showConfirmationDialog");
+            },
+          ),
+        ],
+      );
+    },
+  );
+}
+
+showInformationDialog({
+  @required BuildContext context,
+  @required String title,
+  @required String content,
+}) {
+  Navigation navigation = Navigation();
+  return showDialog<void>(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        title: Text(title),
+        content: new Text(content),
+        actions: <Widget>[
+          new FlatButton(
+            child: new Text(AppLocalizations.of(context).ok),
+            onPressed: () {
+              navigation.pop(context, "DialogBuilder.showInformationDialog");
             },
           ),
         ],

--- a/lib/src/utils/error.dart
+++ b/lib/src/utils/error.dart
@@ -40,4 +40,22 @@
  * for more details.
  */
 
+import 'package:delta_chat_core/delta_chat_core.dart';
+
 const contactDelete = "contact-delete-1";
+
+int getErrorType(Event event) {
+  if (_isErrorEvent(event)) {
+    return event.data1;
+  }
+  return -1;
+}
+
+bool _isErrorEvent(Event event) => event.eventId == Event.error;
+
+String getErrorMessage(Event event) {
+  if (_isErrorEvent(event)) {
+    return event.data2;
+  }
+  return "";
+}


### PR DESCRIPTION
**Link to the given issue**
#6 

**Describe what the problem was / what the new feature is**
No user visible feedback on login errors.

**Describe your solution**
Now listening to error events emitted by the DCC. If an error occurs show it as dialog, but only if the login failed (not during the process, as multiple errors can occur while auto configuring).
