### PR TITLE
 OT-126 Show only chat invites #27 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,7 @@ import 'package:ox_talk/src/main/main_state.dart';
 import 'package:ox_talk/src/main/root.dart';
 import 'package:ox_talk/src/main/splash.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
+import 'package:ox_talk/src/utils/colors.dart';
 import 'package:ox_talk/src/widgets/root_view_switcher.dart';
 
 void main() {
@@ -69,6 +70,10 @@ class OxTalkApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return new MaterialApp(
+      theme: new ThemeData(
+        primaryColor: chatMain,
+        accentColor: accent,
+      ),
       localizationsDelegates: [
         AppLocalizationsDelegate(),
         GlobalMaterialLocalizations.delegate,

--- a/lib/src/base/base_root_child.dart
+++ b/lib/src/base/base_root_child.dart
@@ -41,6 +41,7 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:ox_talk/src/utils/dimensions.dart';
 
 abstract class BaseRootChild extends StatefulWidget {
 
@@ -55,6 +56,10 @@ abstract class BaseRootChild extends StatefulWidget {
   Color getColor();
 
   FloatingActionButton getFloatingActionButton(BuildContext context);
+
+  getElevation() {
+    return appBarElevationDefault;
+  }
 
   List<Widget> getActions(BuildContext context) {
     return _actions;

--- a/lib/src/chat/create_chat.dart
+++ b/lib/src/chat/create_chat.dart
@@ -82,7 +82,6 @@ class _CreateChatState extends State<CreateChat> {
             icon: new Icon(Icons.close),
             onPressed: () => navigation.pop(context, "CreateChat"),
           ),
-          backgroundColor: chatMain,
           title: Text(AppLocalizations.of(context).createChatTitle),
         ),
         body: buildForm()

--- a/lib/src/chat/create_group_chat.dart
+++ b/lib/src/chat/create_group_chat.dart
@@ -83,7 +83,6 @@ class _CreateGroupChatState extends State<CreateGroupChat> {
             icon: new Icon(Icons.close),
             onPressed: () => navigation.pop(context, "CreateGroupChat"),
           ),
-          backgroundColor: chatMain,
           title: Text(AppLocalizations.of(context).createGroupTitle),
           actions: <Widget>[
             IconButton(

--- a/lib/src/contact/contact_import_bloc.dart
+++ b/lib/src/contact/contact_import_bloc.dart
@@ -49,12 +49,10 @@ import 'package:ox_talk/src/contact/contact_import_event.dart';
 import 'package:ox_talk/src/contact/contact_import_state.dart';
 import 'package:ox_talk/src/data/repository.dart';
 import 'package:ox_talk/src/data/repository_manager.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:ox_talk/src/platform/preferences.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 class ContactImportBloc extends Bloc<ContactImportEvent, ContactImportState> {
-  static const PREFERENCE_CONTACTS_SYSTEM_IMPORT_SHOWN = "PREFERENCE_CONTACTS_SYSTEM_IMPORT_SHOWN11";
-
   final Repository<Contact> contactRepository = RepositoryManager.get(RepositoryType.contact);
 
   @override
@@ -74,14 +72,12 @@ class ContactImportBloc extends Bloc<ContactImportEvent, ContactImportState> {
   }
 
   Future<bool> isInitialContactsOpening() async {
-    SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
-    return sharedPreferences.get(PREFERENCE_CONTACTS_SYSTEM_IMPORT_SHOWN) == null ||
-        !sharedPreferences.getBool(PREFERENCE_CONTACTS_SYSTEM_IMPORT_SHOWN);
+    bool systemContactImportShown = await getPreference(preferenceSystemContactsImportShown);
+    return systemContactImportShown == null || !systemContactImportShown;
   }
 
   void markContactsAsInitiallyLoaded() async {
-    SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
-    sharedPreferences.setBool(PREFERENCE_CONTACTS_SYSTEM_IMPORT_SHOWN, true);
+    await setPreference(preferenceSystemContactsImportShown, true);
   }
 
   void loadSystemContacts() async {

--- a/lib/src/data/config.dart
+++ b/lib/src/data/config.dart
@@ -60,6 +60,7 @@ class Config {
   String smtpServer;
   int smtpPort;
   int smtpSecurity;
+  int showEmails;
 
   int get lastUpdate => _lastUpdate;
 
@@ -89,7 +90,7 @@ class Config {
     int serverFlags = await _context.getConfigValue(Context.configServerFlags, ObjectType.int);
     imapSecurity = getSavedImapSecurityOption(serverFlags);
     smtpSecurity = getSavedSmtpSecurityOption(serverFlags);
-    
+    showEmails = await _context.getConfigValue(Context.configShowEmails, ObjectType.int);
     setLastUpdate();
   }
 

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -76,6 +76,8 @@ class AppLocalizations {
 
   String get startTLS => 'StartTLS';
 
+  String get bigDot => '\u2B24';
+
   // No translation + DCC default values which should get adjusted
   String get coreChatStatusDefaultValue => "Sent with my Delta Chat Messenger: https://delta.chat";
 
@@ -112,44 +114,90 @@ class AppLocalizations {
 
   String get camera => Intl.message('Camera', name: 'camera');
 
+  String get invites => Intl.message('Invites', name: 'invites');
+
+  String get chats => Intl.message('Chats', name: 'chats');
+
   // Core
   String get coreChatNoMessages => Intl.message('No messages', name: 'coreChatNoMessages');
+
   String get coreSelf => Intl.message('Me', name: 'coreSelf');
+
   String get coreDraft => Intl.message('Draft', name: 'coreDraft');
+
   String get coreMembers => Intl.message('%1\$d member(s)', name: 'createChatWith');
+
   String get coreContacts => Intl.message('%1\$d contact(s)', name: 'createChatWith');
+
   String get coreVoiceMessage => Intl.message('Voice message', name: 'coreVoiceMessage');
+
   String get coreContactRequest => Intl.message('Contact request', name: 'coreContactRequest');
+
   String get coreImage => Intl.message('Image', name: 'coreImage');
+
   String get coreVideo => Intl.message('Video', name: 'coreVideo');
+
   String get coreAudio => Intl.message('Audio', name: 'coreAudio');
+
   String get coreFile => Intl.message('File', name: 'coreFile');
+
   String get coreGroupHelloDraft => Intl.message('Hello, I\'ve just created this group for us', name: 'coreGroupHelloDraft');
+
   String get coreGroupNameChanged => Intl.message('Group name changed', name: 'coreGroupNameChanged');
+
   String get coreGroupImageChanged => Intl.message('Group image changed', name: 'coreGroupImageChanged');
+
   String get coreGroupMemberAdded => Intl.message('Member added', name: 'coreGroupMemberAdded');
+
   String get coreGroupMemberRemoved => Intl.message('Member removed', name: 'coreGroupMemberRemoved');
+
   String get coreGroupLeft => Intl.message('Group left', name: 'coreGroupLeft');
+
   String get coreGenericError => Intl.message('Error: ', name: 'coreGenericError');
+
   String get coreGif => Intl.message('Gif', name: 'coreGif');
-  String get coreMessageCannotDecrypt => Intl.message('This message cannot be decrypted.\n\n'
+
+  String get coreMessageCannotDecrypt => Intl.message(
+      'This message cannot be decrypted.\n\n'
       '• It might already help to simply reply to this message and ask the sender to send the message again.\n\n'
-      '• In case you re-installed Delta Chat or another email program on this or another device you may want to send an Autocrypt Setup Message from there.', name: 'coreMessageCannotDecrypt');
+      '• In case you re-installed Delta Chat or another email program on this or another device you may want to send an Autocrypt Setup Message from there.',
+      name: 'coreMessageCannotDecrypt');
+
   String get coreReadReceiptSubject => Intl.message('Read receipt', name: 'coreReadReceiptSubject');
-  String get coreReadReceiptBody => Intl.message('This is a read receipt.\n\nIt means the message was displayed on the recipient\'s device, not necessarily that the content was read.', name: 'coreReadReceiptBody');
+
+  String get coreReadReceiptBody => Intl.message(
+      'This is a read receipt.\n\nIt means the message was displayed on the recipient\'s device, not necessarily that the content was read.',
+      name: 'coreReadReceiptBody');
+
   String get coreGroupImageDeleted => Intl.message('Group image deleted', name: 'coreGroupImageDeleted');
+
   String get coreContactVerified => Intl.message('Contact verified', name: 'coreContactVerified');
+
   String get coreContactNotVerified => Intl.message('Cannot verify contact', name: 'coreContactNotVerified');
+
   String get coreContactSetupChanged => Intl.message('Changed setup for contact', name: 'coreContactSetupChanged');
+
   String get coreArchivedChats => Intl.message('Archived chats', name: 'coreArchivedChats');
+
   String get coreAutoCryptSetupSubject => Intl.message('Autocrypt Setup Message', name: 'coreAutoCryptSetupSubject');
-  String get coreAutoCryptSetupBody => Intl.message('This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\n'
-      'To decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.', name: 'coreAutoCryptSetupBody');
+
+  String get coreAutoCryptSetupBody => Intl.message(
+      'This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\n'
+      'To decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.',
+      name: 'coreAutoCryptSetupBody');
+
   String get coreChatSelf => Intl.message('Messages I sent to myself', name: 'coreChatSelf');
-  String get coreLoginErrorCannotLogin => Intl.message('Cannot login. Please check if the email-address and the password are correct.', name: 'coreLoginErrorCannotLogin');
-  String get coreLoginErrorServerResponse => Intl.message('Response from %1\$s: %1\$2\n\n'
-      'Some providers place additional information in your inbox; you can check them it eg. in the web frontend. Consult your provider or friends if you run into problems.', name: 'coreLoginErrorServerResponse');
+
+  String get coreLoginErrorCannotLogin =>
+      Intl.message('Cannot login. Please check if the email-address and the password are correct.', name: 'coreLoginErrorCannotLogin');
+
+  String get coreLoginErrorServerResponse => Intl.message(
+      'Response from %1\$s: %1\$2\n\n'
+      'Some providers place additional information in your inbox; you can check them it eg. in the web frontend. Consult your provider or friends if you run into problems.',
+      name: 'coreLoginErrorServerResponse');
+
   String get coreActionByUser => Intl.message('%1\$s by %1\$2', name: 'coreActionByUser');
+
   String get coreActionByMe => Intl.message('%1\$s by me', name: 'coreActionByMe');
 
   // Form
@@ -202,8 +250,11 @@ class AppLocalizations {
 
   // Chat / chat list / invite list
   String get chatTitle => Intl.message('Chat', name: 'chatTitle');
+
   String get composePlaceholder => Intl.message('Type something...', name: 'composePlaceholder');
+
   String get inviteEmptyList => Intl.message('No invites', name: 'inviteEmptyList');
+
   String get chatListEmpty => Intl.message('No chats', name: 'chatListEmpty');
 
   // Create chat

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -160,7 +160,7 @@ class AppLocalizations {
   String get coreMessageCannotDecrypt => Intl.message(
       'This message cannot be decrypted.\n\n'
       '• It might already help to simply reply to this message and ask the sender to send the message again.\n\n'
-      '• In case you re-installed Delta Chat or another email program on this or another device you may want to send an Autocrypt Setup Message from there.',
+      '• In case you re-installed OX Talk or another email program on this or another device you may want to send an Autocrypt Setup Message from there.',
       name: 'coreMessageCannotDecrypt');
 
   String get coreReadReceiptSubject => Intl.message('Read receipt', name: 'coreReadReceiptSubject');

--- a/lib/src/main/main_bloc.dart
+++ b/lib/src/main/main_bloc.dart
@@ -83,11 +83,11 @@ class MainBloc extends Bloc<MainEvent, MainState> {
   }
 
   _setupDefaultValues(BuildContext context) async {
-      Config config = Config();
-      config.setValue(Context.configSelfStatus, AppLocalizations.of(context).editUserSettingsStatusDefaultValue);
-      config.setValue(Context.configShowEmails, Context.showEmailsAcceptedContacts);
-      String version = await getAppVersion();
-      await setPreference(preferenceAppVersion, version);
+    Config config = Config();
+    config.setValue(Context.configSelfStatus, AppLocalizations.of(context).editUserSettingsStatusDefaultValue);
+    config.setValue(Context.configShowEmails, Context.showEmailsAcceptedContacts);
+    String version = await getAppVersion();
+    await setPreference(preferenceAppVersion, version);
   }
 
   _checkLogin() async {
@@ -98,5 +98,4 @@ class MainBloc extends Bloc<MainEvent, MainState> {
   onLoginSuccess() {
     dispatch(AppLoaded(configured: true));
   }
-
 }

--- a/lib/src/main/main_bloc.dart
+++ b/lib/src/main/main_bloc.dart
@@ -49,6 +49,8 @@ import 'package:ox_talk/src/data/config.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/main/main_event.dart';
 import 'package:ox_talk/src/main/main_state.dart';
+import 'package:ox_talk/src/platform/app_information.dart';
+import 'package:ox_talk/src/platform/preferences.dart';
 
 class MainBloc extends Bloc<MainEvent, MainState> {
   DeltaChatCore _core = DeltaChatCore();
@@ -63,7 +65,10 @@ class MainBloc extends Bloc<MainEvent, MainState> {
       yield MainStateLoading();
       try {
         await _initCore();
-        await _setupDefaultValues(event.context);
+        String appVersion = await getPreference(preferenceAppVersion);
+        if (appVersion == null || appVersion.isEmpty) {
+          await _setupDefaultValues(event.context);
+        }
         _checkLogin();
       } catch (error) {
         yield MainStateFailure(error: error.toString());
@@ -78,11 +83,11 @@ class MainBloc extends Bloc<MainEvent, MainState> {
   }
 
   _setupDefaultValues(BuildContext context) async {
-    String status = await _context.getConfigValue(Context.configSelfStatus);
-    if (status == AppLocalizations.of(context).coreChatStatusDefaultValue) {
       Config config = Config();
       config.setValue(Context.configSelfStatus, AppLocalizations.of(context).editUserSettingsStatusDefaultValue);
-    }
+      config.setValue(Context.configShowEmails, Context.showEmailsAcceptedContacts);
+      String version = await getAppVersion();
+      await setPreference(preferenceAppVersion, version);
   }
 
   _checkLogin() async {

--- a/lib/src/main/root.dart
+++ b/lib/src/main/root.dart
@@ -69,6 +69,7 @@ class _RootState extends State<Root> {
         backgroundColor: child.getColor(),
         title: Text(child.getTitle(context)),
         actions: child.getActions(context),
+        elevation: child.getElevation(),
       ),
       body: RootViewSwitcher(child),
       bottomNavigationBar: _buildBottomBar(),

--- a/lib/src/platform/app_information.dart
+++ b/lib/src/platform/app_information.dart
@@ -1,0 +1,60 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:package_info/package_info.dart';
+
+getAppVersion() async {
+  PackageInfo packageInfo = await getPackageInfo();
+  String version = packageInfo.version;
+  String buildNumber = packageInfo.buildNumber;
+  return "$version ($buildNumber)";
+}
+
+Future<PackageInfo> getPackageInfo() async {
+  PackageInfo packageInfo = await PackageInfo.fromPlatform();
+  return packageInfo;
+}
+
+getAppName() async {
+  PackageInfo packageInfo = await getPackageInfo();
+  return packageInfo.appName;
+}

--- a/lib/src/platform/preferences.dart
+++ b/lib/src/platform/preferences.dart
@@ -1,0 +1,70 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+const preferenceSystemContactsImportShown = "preferenceSystemContactsImportShown";
+const preferenceAppVersion = "preferenceAppVersion";
+
+Future<dynamic> getPreference(String key) async {
+  SharedPreferences sharedPreferences = await getSharedPreferences();
+  return sharedPreferences.get(key);
+}
+
+Future<SharedPreferences> getSharedPreferences() async {
+  return await SharedPreferences.getInstance();
+}
+
+Future<void> setPreference(String key, value) async {
+  SharedPreferences sharedPreferences = await getSharedPreferences();
+  if (value is bool) {
+    sharedPreferences.setBool(key, value);
+  } else if (value is int) {
+    sharedPreferences.setInt(key, value);
+  } else if (value is double) {
+    sharedPreferences.setDouble(key, value);
+  } else if (value is String) {
+    sharedPreferences.setString(key, value);
+  } else if (value is List<String>) {
+    sharedPreferences.setStringList(key, value);
+  }
+}

--- a/lib/src/profile/profile.dart
+++ b/lib/src/profile/profile.dart
@@ -155,7 +155,7 @@ class _ProfileState extends State<ProfileView> {
             ),
             buildOutlineButton(
               context: context,
-              color: Theme.of(context).primaryColor,
+              color: accent,
               child: Text(AppLocalizations.of(context).profileEditButton),
               onPressed: editUserSettings,
             ),

--- a/lib/src/utils/colors.dart
+++ b/lib/src/utils/colors.dart
@@ -44,13 +44,6 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
-// Global
-const Color textDisabled = Colors.black26;
-const Color testLessImportant = Colors.black45;
-const Color appBarIcon = Colors.white;
-const Color textColorInverted = Colors.white;
-const Color transparent = Colors.transparent;
-
 Color rgbColorFromInt(int color, [int alpha]) {
   if (alpha == null) {
     alpha = 255;
@@ -70,6 +63,14 @@ int _blue(int color) {
   return color & 0xFF;
 }
 
+// Global
+const Color textDisabled = Colors.black26;
+const Color testLessImportant = Colors.black45;
+const Color appBarIcon = Colors.white;
+const Color textColorInverted = Colors.white;
+const Color transparent = Colors.transparent;
+const Color accent = Colors.pink;
+
 // Progress
 final Color progressBackground = Colors.black45;
 
@@ -78,7 +79,7 @@ const Color loginHintBackground = Colors.blueGrey;
 
 // List
 const Color listAvatarForegroundColor = Colors.white;
-final Color listAvatarDefaultBackgroundColor = Colors.blue[700];
+final Color listAvatarDefaultBackgroundColor = Colors.transparent;
 
 // Chat
 const Color chatMain = Colors.blue;

--- a/lib/src/utils/dimensions.dart
+++ b/lib/src/utils/dimensions.dart
@@ -56,9 +56,11 @@ const listItemPaddingBig = 16.0;
 const listItemPadding = 8.0;
 const listItemPaddingSmall = 4.0;
 const listAvatarRadius = 24.0;
+const listAvatarDiameter = listAvatarRadius * 2;
 
 // AppBar
 const appBarAvatarTextPadding = 16.0;
+const appBarElevationDefault = 4.0;
 
 // Icons
 const iconTextPadding = 4.0;

--- a/lib/src/widgets/avatar.dart
+++ b/lib/src/widgets/avatar.dart
@@ -59,6 +59,12 @@ class Avatar extends StatelessWidget {
     if (imagePath != null && imagePath.isNotEmpty) {
       avatarImage = FileImage(File(imagePath));
     }
+    if (avatarImage == null && (initials == null || initials.isEmpty)) {
+      return Container(
+        height: listAvatarDiameter,
+        width: listAvatarDiameter,
+      );
+    }
     return CircleAvatar(
       radius: listAvatarRadius,
       foregroundColor: listAvatarForegroundColor,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   image_cropper: ^1.0.0
   image_picker: ^0.5.0+3
   open_file: ^1.2.2+2
+  package_info: ^0.4.0+2
   path_provider: ^0.5.0+1
   permission_handler: ^3.0.0
   shared_preferences: ^0.5.1+1


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-talk/issues/27

**Describe what the problem was / what the new feature is**
All incoming mails were collected in the invites view. Only messages by other chat clients should be added to the invites view.

**Describe your solution**
Used the updated DCC to filter the incoming mails.

**Additional context**
- Added the accent color
- Adjusted the tab bar color in the chat list 
- Added an indicator for new invites
- Added better handling for shared preferences
- Added to ability to receive app information via the package_info plugin (version, build numbers and so on)
- Optimized the initial setup of the app (default values are now applied reliable at the first app start)
- Optimized loading performance of avatar list items