### PR TITLE
OT-129 Edit account settings are not applied #29

### DIFF
--- a/lib/src/data/config.dart
+++ b/lib/src/data/config.dart
@@ -103,15 +103,10 @@ class Config {
     await load();
   }
 
-  void setValue(String key, var value, [bool allowNullAndEmptyValues, ObjectType enforceType]) {
-    if (allowNullAndEmptyValues == null || !allowNullAndEmptyValues) {
-      if ((value == null || (value is String && value.isEmpty))) {
-        return;
-      }
-    } else {
-      if (enforceType == null) {
-        throw ArgumentError("allowNullAndEmptyValues is true but no specific type was set via enforceType.");
-      }
+  Future<void> setValue(String key, var value) async {
+    ObjectType type = isTypeInt(key) ? ObjectType.int : ObjectType.String;
+    if (key != Context.configDisplayName && key != Context.configSelfAvatar && key != Context.configSelfStatus) {
+      value = convertEmptyStringToNull(value);
     }
 
     switch (key) {
@@ -147,26 +142,31 @@ class Config {
         break;
       case Context.configServerFlags:
         int sel = 0;
-        if((value & Context.serverFlagsImapSsl) != 0) sel = 1;
-        if((value & Context.serverFlagsImapStartTls) != 0) sel = 2;
-        if((value & Context.serverFlagsImapPlain) !=0 ) sel = 3;
+        if ((value & Context.serverFlagsImapSsl) != 0) sel = 1;
+        if ((value & Context.serverFlagsImapStartTls) != 0) sel = 2;
+        if ((value & Context.serverFlagsImapPlain) != 0) sel = 3;
         imapSecurity = sel;
 
         sel = 0;
-        if((value & Context.serverFlagsSmtpSsl) != 0) sel = 1;
-        if((value & Context.serverFlagsSmtpStartTls) != 0) sel = 2;
-        if((value & Context.serverFlagsSmtpPlain) != 0) sel = 3;
+        if ((value & Context.serverFlagsSmtpSsl) != 0) sel = 1;
+        if ((value & Context.serverFlagsSmtpStartTls) != 0) sel = 2;
+        if ((value & Context.serverFlagsSmtpPlain) != 0) sel = 3;
         smtpSecurity = sel;
     }
-    if (enforceType != null) {
-      _context.setConfigValue(key, value, enforceType);
-    } else {
-      _context.setConfigValue(key, value);
-    }
+    await _context.setConfigValue(key, value, type);
     setLastUpdate();
   }
+
+  bool isTypeInt(String key) => key == Context.configServerFlags || key == Context.configShowEmails;
 
   String get smtpPortAsString => smtpPort != null ? (smtpPort > 0 ? smtpPort.toString() : "") : null;
 
   String get imapPortAsString => imapPort != null ? (imapPort > 0 ? imapPort.toString() : "") : null;
+
+  convertEmptyStringToNull(value) {
+    if (value == null || (value is String && value.isEmpty)) {
+      return null;
+    }
+    return value;
+  }
 }

--- a/lib/src/data/repository.dart
+++ b/lib/src/data/repository.dart
@@ -157,7 +157,6 @@ abstract class Repository<T extends Base> {
   }
 
   void removeListener(BaseRepositoryStreamHandler streamHandler) {
-    streamHandler.tearDown();
     if (streamHandler is RepositoryStreamHandler) {
       tearDownCoreListener(streamHandler.eventId, streamHandler.listenerId);
     } else if (streamHandler is RepositoryMultiEventStreamHandler) {

--- a/lib/src/data/repository_stream_handler.dart
+++ b/lib/src/data/repository_stream_handler.dart
@@ -74,10 +74,6 @@ abstract class BaseRepositoryStreamHandler {
         break;
     }
   }
-
-  tearDown() {
-    _streamController.close();
-  }
 }
 
 class RepositoryStreamHandler extends BaseRepositoryStreamHandler {

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -340,6 +340,13 @@ class AppLocalizations {
 
   // Account settings
   String get editAccountSettingsTitle => Intl.message('Edit account settings', name: 'editAccountSettingsTitle');
+
+  String get editAccountDataProgressMessage => Intl.message('Applying new settings, this may take a moment', name: 'editAccountDataProgressMessage');
+
+  String get editAccountSettingsSuccess => Intl.message('Account settings succesfully changed', name: 'editAccountSettingsSuccess');
+
+  String get editAccountSettingsErrorDialogTitle => Intl.message('Configuration change aborted', name: 'editAccountSettingsErrorDialogTitle');
+
 }
 
 class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/src/login/login_bloc.dart
+++ b/lib/src/login/login_bloc.dart
@@ -68,7 +68,15 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     if (event is LoginButtonPressed) {
       yield LoginStateLoading(progress: 0);
       try {
-        _setupConfig(event);
+        await _setupConfig(event);
+        _registerListeners();
+        _context.configure();
+      } catch (error) {
+        yield LoginStateFailure(error: error.toString());
+      }
+    } else if (event is EditButtonPressed) {
+      yield LoginStateLoading(progress: 0);
+      try {
         _registerListeners();
         _context.configure();
       } catch (error) {
@@ -96,22 +104,22 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     super.dispose();
   }
 
-  void _setupConfig(LoginButtonPressed event) {
+  Future<void> _setupConfig(LoginButtonPressed event) async {
     Config config = Config();
-    config.setValue(Context.configAddress, event.email);
-    config.setValue(Context.configMailPassword, event.password);
-    config.setValue(Context.configMailUser, event.imapLogin);
-    config.setValue(Context.configMailServer, event.imapServer);
-    config.setValue(Context.configMailPassword, event.imapPort);
-    config.setValue(Context.configSendUser, event.smtpLogin);
-    config.setValue(Context.configSendPassword, event.smtpPassword);
-    config.setValue(Context.configSendServer, event.smtpServer);
-    config.setValue(Context.configSendPort, event.smtpPort);
+    await config.setValue(Context.configAddress, event.email);
+    await config.setValue(Context.configMailPassword, event.password);
+    await config.setValue(Context.configMailUser, event.imapLogin);
+    await config.setValue(Context.configMailServer, event.imapServer);
+    await config.setValue(Context.configMailPort, event.imapPort);
+    await config.setValue(Context.configSendUser, event.smtpLogin);
+    await config.setValue(Context.configSendPassword, event.smtpPassword);
+    await config.setValue(Context.configSendServer, event.smtpServer);
+    await config.setValue(Context.configSendPort, event.smtpPort);
     int imapSecurity = event.imapSecurity;
     int smtpSecurity = event.smtpSecurity;
     int serverFlags = createServerFlagInteger(imapSecurity, smtpSecurity);
 
-    config.setValue(Context.configServerFlags, serverFlags, false, ObjectType.int);
+    await config.setValue(Context.configServerFlags, serverFlags);
   }
 
   void _updateConfig() {

--- a/lib/src/platform/system.dart
+++ b/lib/src/platform/system.dart
@@ -40,42 +40,6 @@
  * for more details.
  */
 
-import 'package:meta/meta.dart';
+import 'package:flutter/services.dart';
 
-abstract class LoginEvent {}
-
-class LoginButtonPressed extends LoginEvent {
-  final String email;
-  final String password;
-  final String imapLogin;
-  final String imapServer;
-  final int imapPort;
-  final int imapSecurity;
-  final String smtpLogin;
-  final String smtpPassword;
-  final String smtpServer;
-  final int smtpPort;
-  final int smtpSecurity;
-
-  LoginButtonPressed(
-      {@required this.email,
-      @required this.password,
-      @required this.imapLogin,
-      @required this.imapServer,
-      @required this.imapPort,
-      @required this.imapSecurity,
-      @required this.smtpLogin,
-      @required this.smtpPassword,
-      @required this.smtpServer,
-      @required this.smtpPort,
-      @required this.smtpSecurity});
-}
-
-class EditButtonPressed extends LoginEvent {}
-
-class LoginProgress extends LoginEvent {
-  final int progress;
-  final error;
-
-  LoginProgress(this.progress, [this.error]);
-}
+hideKeyboard() => SystemChannels.textInput.invokeMethod('TextInput.hide');

--- a/lib/src/profile/user_bloc.dart
+++ b/lib/src/profile/user_bloc.dart
@@ -89,28 +89,28 @@ class UserBloc extends Bloc<UserEvent, UserState> {
 
   void _saveUserPersonalData(UserPersonalDataChanged event) async {
     Config config = Config();
-    config.setValue(Context.configDisplayName, event.username, true, ObjectType.String);
-    config.setValue(Context.configSelfStatus, event.status, true, ObjectType.String);
+    await config.setValue(Context.configDisplayName, event.username);
+    await config.setValue(Context.configSelfStatus, event.status);
     var avatarPath = event.avatarPath;
-    config.setValue(Context.configSelfAvatar, avatarPath, true, ObjectType.String);
+    await config.setValue(Context.configSelfAvatar, avatarPath);
     dispatch(UserChanged(config: config));
   }
 
-  void _saveUserAccountData(UserAccountDataChanged event) {
+  void _saveUserAccountData(UserAccountDataChanged event) async {
     Config config = Config();
-    config.setValue(Context.configMailUser, event.imapLogin, true, ObjectType.String);
-    config.setValue(Context.configMailPassword, event.imapPassword, true, ObjectType.String);
-    config.setValue(Context.configMailServer, event.imapServer, true, ObjectType.String);
-    config.setValue(Context.configMailPort, event.imapPort, true, ObjectType.String);
-    config.setValue(Context.configSendUser, event.smtpLogin, true, ObjectType.String);
-    config.setValue(Context.configSendPassword, event.smtpPassword, true, ObjectType.String);
-    config.setValue(Context.configSendServer, event.smtpServer, true, ObjectType.String);
-    config.setValue(Context.configSendPort, event.smtpPort, true, ObjectType.String);
+    await config.setValue(Context.configMailUser, event.imapLogin);
+    await config.setValue(Context.configMailPassword, event.imapPassword);
+    await config.setValue(Context.configMailServer, event.imapServer);
+    await config.setValue(Context.configMailPort, event.imapPort);
+    await config.setValue(Context.configSendUser, event.smtpLogin);
+    await config.setValue(Context.configSendPassword, event.smtpPassword);
+    await config.setValue(Context.configSendServer, event.smtpServer);
+    await config.setValue(Context.configSendPort, event.smtpPort);
     int imapSecurity = event.imapSecurity;
     int smtpSecurity = event.smtpSecurity;
     int serverFlags = createServerFlagInteger(imapSecurity, smtpSecurity);
 
-    config.setValue(Context.configServerFlags, serverFlags, false, ObjectType.int);
+    await config.setValue(Context.configServerFlags, serverFlags);
     dispatch(UserChanged(config: config));
   }
 }


### PR DESCRIPTION
**Link to the given issue**
#29 

**Describe what the problem was / what the new feature is**
Context.configure() wasn't called.

**Describe your solution**
Added the configure logic and error handling.

**Additional context**
- Simplified the config logic
- Removed wrong "tearDown" and "close" methods for streams
- Added system.dart as helper class for system calls