### PR TITLE
OT-143 Chat title is not updated after contact name change #37

### DIFF
--- a/lib/src/contact/contact_change_bloc.dart
+++ b/lib/src/contact/contact_change_bloc.dart
@@ -54,6 +54,7 @@ import 'package:ox_talk/src/utils/error.dart';
 
 class ContactChangeBloc extends Bloc<ContactChangeEvent, ContactChangeState> {
   final Repository<Contact> contactRepository = RepositoryManager.get(RepositoryType.contact);
+  final Repository<Chat> chatRepository = RepositoryManager.get(RepositoryType.chat);
 
   @override
   ContactChangeState get initialState => ContactChangeStateInitial();
@@ -91,7 +92,10 @@ class ContactChangeBloc extends Bloc<ContactChangeEvent, ContactChangeState> {
       dispatch(ContactAdded(id));
     } else {
       Contact contact = contactRepository.get(id);
-      contact.prepareReloadValue(Contact.methodContactGetName);
+      contact.set(Contact.methodContactGetName, name);
+      int chatId = await context.getChatByContactId(id);
+      Chat chat = chatRepository.get(chatId);
+      chat.set(Chat.methodChatGetName, name);
       dispatch(ContactEdited());
     }
   }


### PR DESCRIPTION
**Link to the given issue**
#37 

**Describe your solution**
- The chat name is now directly set on contact name change
- The chat name is now directly set instead of resetting it and waiting for the next request to the DCC to get the data
