### PR TITLE
Create chat profile view #36 OT-142

### DIFF
--- a/lib/src/chat/chat_bloc.dart
+++ b/lib/src/chat/chat_bloc.dart
@@ -75,6 +75,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
         name: event.name,
         subTitle: event.subTitle,
         color: event.color,
+        isSelfTalk: event.isSelfTalk,
         isGroupChat: event.isGroupChat,
       );
     }
@@ -85,8 +86,9 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
     String name = await chat.getName();
     String subTitle = await chat.getSubtitle();
     int colorValue = await chat.getColor();
+    bool isSelfTalk = await chat.isSelfTalk();
     _isGroup = await chat.isGroup();
     Color color = rgbColorFromInt(colorValue);
-    dispatch(ChatLoaded(name, subTitle, color, _isGroup));
+    dispatch(ChatLoaded(name, subTitle, color, isSelfTalk, _isGroup));
   }
 }

--- a/lib/src/chat/chat_event.dart
+++ b/lib/src/chat/chat_event.dart
@@ -54,7 +54,8 @@ class ChatLoaded extends ChatEvent {
   final String name;
   final String subTitle;
   final Color color;
+  final bool isSelfTalk;
   final bool isGroupChat;
 
-  ChatLoaded(this.name, this.subTitle, this.color, this.isGroupChat);
+  ChatLoaded(this.name, this.subTitle, this.color, this.isSelfTalk, this.isGroupChat);
 }

--- a/lib/src/chat/chat_profile_group_contact_item.dart
+++ b/lib/src/chat/chat_profile_group_contact_item.dart
@@ -39,70 +39,42 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
  * for more details.
  */
+ 
+import 'package:flutter/material.dart';
+import 'package:ox_talk/src/contact/contact_item_bloc.dart';
+import 'package:ox_talk/src/contact/contact_item_event.dart';
+import 'package:ox_talk/src/contact/contact_item_builder_mixin.dart';
 
-import 'dart:core';
+class ChatProfileGroupContactItem extends StatefulWidget {
+  final int _contactId;
 
-// Global
-const zero = 0.0;
-const dividerHeight = 1.0;
+  ChatProfileGroupContactItem(this._contactId, key) : super(key: Key(key));
 
-// Progress
-const verticalPaddingSmall = 8.0;
-const verticalPadding = 16.0;
+  @override
+   _ChatProfileGroupContactItemState createState() => _ChatProfileGroupContactItemState();
+ }
 
-// List
-const listItemHeaderPadding = 8.0;
-const listItemPaddingBig = 16.0;
-const listItemPadding = 8.0;
-const listItemPaddingSmall = 4.0;
-const listAvatarRadius = 24.0;
-const listAvatarDiameter = listAvatarRadius * 2;
+ class _ChatProfileGroupContactItemState extends State<ChatProfileGroupContactItem> with ContactItemBuilder{
+   ContactItemBloc _contactBloc = ContactItemBloc();
 
-// AppBar
-const appBarAvatarTextPadding = 16.0;
-const appBarElevationDefault = 4.0;
+   @override
+   void initState() {
+     super.initState();
+     _contactBloc.dispatch(RequestContact(widget._contactId));
+   }
 
-// Icons
-const iconTextPadding = 4.0;
-const iconFormPadding = 8.0;
-const iconSize = 18.0;
+   @override
+   void dispose() {
+    _contactBloc.dispose();
+    super.dispose();
+  }
 
-// Chat
-const composerHorizontalPadding = 8.0;
-const composerTextFieldPadding = 8.0;
-const composeTextBorderRadius = 24.0;
+  @override
+   Widget build(BuildContext context) {
+    return getBlocBuilder(_contactBloc, onContactTapped);
+   }
 
-// Chat profile
-const chatProfileDividerPadding = 8.0;
-
-//Attachment preview
-const attachmentDividerPadding = 4.0;
-const previewMaxSize = 100.0;
-const previewDefaultIconSize = 100.0;
-const previewCloseIconBorderRadius = 20.0;
-const previewCloseIconSize = 30.0;
-const previewFileNamePadding = 4.0;
-
-// Forms
-const formHorizontalPadding = 16.0;
-const formVerticalPadding = 16.0;
-
-// Messages
-const messagesHorizontalPadding = 8.0;
-const messagesVerticalPadding = 8.0;
-const messagesInnerPadding = 8.0;
-const messagesContentTimePadding = 8.0;
-const messagesBoxRadius = 20.0;
-const messagesBlurRadius = 2.0;
-const messagesFileIconSize = 30.0;
-
-// Profile
-const profileVerticalPadding = 8.0;
-const profileSectionsVerticalPadding = 36.0;
-const profileAvatarPlaceholderIconSize = 60.0;
-const profileAvatarMaxRadius = 64.0;
-
-const editUserAvatarVerticalPadding = 24.0;
-const editUserAvatarEditIconSize = 36.0;
-const editUserAvatarImageMaxSize = 512;
-const editUserAvatarRation = 1.0;
+   onContactTapped(String name, String email) async {
+     //Not implemented yet
+   }
+ }

--- a/lib/src/chat/chat_profile_group_view.dart
+++ b/lib/src/chat/chat_profile_group_view.dart
@@ -1,0 +1,138 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_talk/src/chat/chat_profile_group_contact_item.dart';
+import 'package:ox_talk/src/contact/contact_item.dart';
+import 'package:ox_talk/src/contact/contact_list_bloc.dart';
+import 'package:ox_talk/src/contact/contact_list_event.dart';
+import 'package:ox_talk/src/contact/contact_list_state.dart';
+import 'package:ox_talk/src/l10n/localizations.dart';
+import 'package:ox_talk/src/utils/dimensions.dart';
+import 'package:ox_talk/src/utils/styles.dart';
+
+class ChatProfileGroupView extends StatefulWidget {
+  final int _chatId;
+  final String _chatName;
+  final Color _chatColor;
+
+  ChatProfileGroupView(this._chatId, this._chatName, this._chatColor);
+
+  @override
+  _ChatProfileGroupViewState createState() => _ChatProfileGroupViewState();
+}
+
+class _ChatProfileGroupViewState extends State<ChatProfileGroupView> {
+  ContactListBloc _contactListBloc = ContactListBloc();
+
+  @override
+  void initState() {
+    super.initState();
+    _contactListBloc.dispatch(RequestChatContacts(widget._chatId));
+  }
+
+  @override
+  void dispose() {
+    _contactListBloc.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: CircleAvatar(
+              maxRadius: profileAvatarMaxRadius,
+              backgroundColor: widget._chatColor,
+              child: Text(
+                widget._chatName.substring(0,1),
+                style: chatProfileAvatarInitialText,
+              ),
+            ),
+          ),
+          Text(
+            widget._chatName,
+            style: defaultText,
+          ),
+          Padding(
+            padding: EdgeInsets.all(chatProfileDividerPadding),
+            child: Divider(height: dividerHeight,),
+          ),
+          _buildGroupMemberList()
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGroupMemberList() {
+    return BlocBuilder(
+      bloc: _contactListBloc,
+      builder: (context, state){
+        if(state is ContactListStateSuccess){
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(AppLocalizations.of(context).chatProfileGroupMemberCounter(state.contactIds.length)),
+              Flexible(
+                child: ListView.builder(
+                  shrinkWrap: true,
+                  physics: NeverScrollableScrollPhysics(),
+                  padding: EdgeInsets.all(listItemPadding),
+                  itemCount: state.contactIds.length,
+                  itemBuilder: (BuildContext context, int index) {
+                    var contactId = state.contactIds[index];
+                    var key = "$contactId-${state.contactLastUpdateValues[index]}";
+                    return ChatProfileGroupContactItem(contactId, key);
+                  })
+              )
+            ],
+          );
+        }
+      }
+    );
+  }
+}

--- a/lib/src/chat/chat_profile_single_view.dart
+++ b/lib/src/chat/chat_profile_single_view.dart
@@ -1,0 +1,171 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_talk/src/contact/contact_change_bloc.dart';
+import 'package:ox_talk/src/contact/contact_change_event.dart';
+import 'package:ox_talk/src/contact/contact_item_bloc.dart';
+import 'package:ox_talk/src/contact/contact_item_event.dart';
+import 'package:ox_talk/src/contact/contact_item_state.dart';
+import 'package:ox_talk/src/l10n/localizations.dart';
+import 'package:ox_talk/src/navigation/navigation.dart';
+import 'package:ox_talk/src/utils/dimensions.dart';
+import 'package:ox_talk/src/utils/styles.dart';
+import 'package:ox_talk/src/utils/toast.dart';
+
+class ChatProfileSingleView extends StatefulWidget {
+  final int _chatId;
+  final int _contactId;
+  final bool _isSelfTalk;
+
+  ChatProfileSingleView(this._chatId, this._isSelfTalk, this._contactId, key) : super(key: Key(key));
+
+  @override
+  _ChatProfileSingleViewState createState() => _ChatProfileSingleViewState();
+}
+
+class _ChatProfileSingleViewState extends State<ChatProfileSingleView> {
+  ContactItemBloc _contactItemBloc = ContactItemBloc();
+  Navigation navigation = Navigation();
+
+  @override
+  void initState() {
+    super.initState();
+    _contactItemBloc.dispatch(RequestContact(widget._contactId));
+  }
+
+  @override
+  void dispose() {
+    _contactItemBloc.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder(
+      bloc: _contactItemBloc,
+      builder: (context, state){
+        if(state is ContactItemStateSuccess){
+          return _buildSingleProfileInfo(state.name, state.email, state.color);
+        }
+        else{
+          return Container();
+        }
+      }
+    );
+  }
+
+  Widget _buildSingleProfileInfo(String chatName, String email, Color color) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        Padding(
+          padding: EdgeInsets.symmetric(vertical: 16.0),
+          child: CircleAvatar(
+            maxRadius: profileAvatarMaxRadius,
+            backgroundColor: color,
+            child: Text(
+              chatName.isNotEmpty ? chatName.substring(0,1) : email.substring(0,1),
+              style: chatProfileAvatarInitialText,
+            ),
+          ),
+        ),
+        chatName.isNotEmpty ? Text(
+          chatName,
+          style: defaultText,
+        ) : Container(),
+        InkWell(
+          onTap: () => {
+          Clipboard.setData(new ClipboardData(text: email)),
+          showToast(AppLocalizations.of(context).chatProfileClipboardToastMessage)
+          },
+          child: Text(
+            email,
+            style: defaultText,
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.all(chatProfileDividerPadding),
+          child: Divider(height: dividerHeight,),
+        ),
+        !widget._isSelfTalk ? Card(
+          child: ListTile(
+            title: Text(AppLocalizations.of(context).chatProfileBlockContactButtonText,),
+            onTap: () => _showBlockContactDialog(),
+          ),
+        ): Container(),
+      ],
+    );
+  }
+
+  _showBlockContactDialog(){
+    return showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          content: new Text(AppLocalizations.of(context).chatProfileBlockContactInfoText),
+          actions: <Widget>[
+            new FlatButton(
+              child: new Text(AppLocalizations.of(context).cancel),
+              onPressed: () {
+                navigation.pop(context, "InviteItemTappedDialog");
+              },
+            ),
+            new FlatButton(
+              child: new Text(AppLocalizations.of(context).block),
+              onPressed: () {
+                _blockContact();
+              },
+            ),
+          ],
+        );
+      });
+  }
+
+  _blockContact() {
+    ContactChangeBloc contactChangeBloc = ContactChangeBloc();
+    contactChangeBloc.dispatch(BlockContact(widget._contactId, widget._chatId));
+    navigation.popUntil(context, ModalRoute.withName(Navigation.ROUTES_ROOT), "ChatProfileSingleContact");
+  }
+}

--- a/lib/src/chat/chat_profile_view.dart
+++ b/lib/src/chat/chat_profile_view.dart
@@ -1,17 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_talk/src/chat/chat_bloc.dart';
 import 'package:ox_talk/src/chat/chat_event.dart';
+import 'package:ox_talk/src/chat/chat_profile_group_view.dart';
+import 'package:ox_talk/src/chat/chat_profile_single_view.dart';
 import 'package:ox_talk/src/chat/chat_state.dart';
 import 'package:ox_talk/src/contact/contact_change_bloc.dart';
 import 'package:ox_talk/src/contact/contact_change_event.dart';
+import 'package:ox_talk/src/contact/contact_item.dart';
 import 'package:ox_talk/src/contact/contact_item_bloc.dart';
 import 'package:ox_talk/src/contact/contact_item_event.dart';
 import 'package:ox_talk/src/contact/contact_item_state.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
+import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
+import 'package:ox_talk/src/utils/dimensions.dart';
+import 'package:ox_talk/src/utils/styles.dart';
+import 'package:ox_talk/src/utils/toast.dart';
 
 class ChatProfileView extends StatefulWidget {
   final int _chatId;
@@ -49,81 +57,27 @@ class _ChatProfileViewState extends State<ChatProfileView> {
         bloc: _chatBloc,
         builder: (context, state){
           if(state is ChatStateSuccess){
-            return _buildContactInfo();
+            if(state.isGroupChat){
+              return ChatProfileGroupView(widget._chatId, state.name, state.color);
+            }else{
+              bool _isSelfTalk = state.isSelfTalk;
+              return BlocBuilder(
+                bloc: _contactListBloc,
+                builder: (context, state){
+                  if(state is ContactListStateSuccess){
+                    var key = "${state.contactIds[0]}-${state.contactLastUpdateValues[0]}";
+                    return ChatProfileSingleView(widget._chatId, _isSelfTalk, state.contactIds[0], key);
+                  }else{
+                    return Container();
+                  }
+                }
+              );
+            }
           } else {
             return Container();
           }
         }
       )
     );
-  }
-
-  Widget _buildContactInfo() {
-    return BlocBuilder(
-      bloc: _contactListBloc,
-      builder: (context, state){
-        if(state is ContactListStateSuccess){
-          if(state.contactIds.length == 1){
-            var contactId = state.contactIds[0];
-            var key = "$contactId-${state.contactLastUpdateValues[0]}";
-            return ChatProfileSingleContact(state.contactIds[0], widget._chatId, key);
-          }else{
-            var contactId = state.contactIds[0];
-            var key = "$contactId-${state.contactLastUpdateValues[0]}";
-            return ChatProfileSingleContact(state.contactIds[0], widget._chatId, key);
-          }
-        }else {
-          return Container();
-        }
-      }
-    );
-  }
-}
-
-class ChatProfileSingleContact extends StatefulWidget {
-  final int _contactId;
-  final int _chatId;
-
-  ChatProfileSingleContact(this._contactId, this._chatId, key) : super(key: Key(key));
-
-  @override
-  _ChatProfileSingleContactState createState() => _ChatProfileSingleContactState();
-}
-
-class _ChatProfileSingleContactState extends State<ChatProfileSingleContact> {
-  ContactItemBloc _contactItemBloc = ContactItemBloc();
-
-  Navigation navigation = Navigation();
-
-  @override
-  void initState() {
-    super.initState();
-    _contactItemBloc.dispatch(RequestContact(widget._contactId));
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder(
-      bloc: _contactItemBloc, 
-      builder: (context, state){
-        if(state is ContactItemStateSuccess){
-          return Column(
-            children: <Widget>[
-              Text(state.email),
-              RaisedButton(onPressed: () => _blockContact(), child: Text("Block contact"))
-            ],
-          );
-        }
-        else{
-          return Container();
-        }
-      }
-    );
-  }
-
-  _blockContact() {
-    ContactChangeBloc contactChangeBloc = ContactChangeBloc();
-    contactChangeBloc.dispatch(BlockContact(widget._contactId, widget._chatId));
-    navigation.popUntil(context, ModalRoute.withName(Navigation.ROUTES_ROOT), "ChatProfileSingleContact");
   }
 }

--- a/lib/src/chat/chat_state.dart
+++ b/lib/src/chat/chat_state.dart
@@ -75,9 +75,10 @@ class ChatStateSuccess extends ChatState {
   final String name;
   final String subTitle;
   final Color color;
+  final bool isSelfTalk;
   final bool isGroupChat;
 
-  ChatStateSuccess({@required this.name, @required this.subTitle, @required this.color, @required this.isGroupChat})
+  ChatStateSuccess({@required this.name, @required this.subTitle, @required this.color, @required this.isSelfTalk, @required this.isGroupChat})
       : super(
           isLoading: false,
           isSuccess: true,

--- a/lib/src/contact/contact_item.dart
+++ b/lib/src/contact/contact_item.dart
@@ -77,6 +77,12 @@ class _ContactItemState extends State<ContactItem> with ContactItemBuilder {
   }
 
   @override
+  void dispose() {
+    _contactBloc.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return getBlocBuilder(_contactBloc, onContactTapped);
   }

--- a/lib/src/contact/contact_item_builder_mixin.dart
+++ b/lib/src/contact/contact_item_builder_mixin.dart
@@ -40,48 +40,6 @@
  * for more details.
  */
 
-/*
- * OPEN-XCHANGE legal information
- *
- * All intellectual property rights in the Software are protected by
- * international copyright laws.
- *
- *
- * In some countries OX, OX Open-Xchange and open xchange
- * as well as the corresponding Logos OX Open-Xchange and OX are registered
- * trademarks of the OX Software GmbH group of companies.
- * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
- * Instead, you are allowed to use these Logos according to the terms and
- * conditions of the Creative Commons License, Version 2.5, Attribution,
- * Non-commercial, ShareAlike, and the interpretation of the term
- * Non-commercial applicable to the aforementioned license is published
- * on the web site https://www.open-xchange.com/terms-and-conditions/.
- *
- * Please make sure that third-party modules and libraries are used
- * according to their respective licenses.
- *
- * Any modifications to this package must retain all copyright notices
- * of the original copyright holder(s) for the original code used.
- *
- * After any such modifications, the original and derivative code shall remain
- * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
- * https://www.open-xchange.com/legal/. The contributing author shall be
- * given Attribution for the derivative code and a license granting use.
- *
- * Copyright (C) 2016-2020 OX Software GmbH
- * Mail: info@open-xchange.com
- *
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
- * for more details.
- */
-
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/lib/src/contact/contact_list_bloc.dart
+++ b/lib/src/contact/contact_list_bloc.dart
@@ -86,8 +86,8 @@ class ContactListBloc extends Bloc<ContactListEvent, ContactListState> {
     } else if(event is RequestChatContacts){
       yield ContactListStateLoading();
       try {
-        contactRepository = RepositoryManager.get(RepositoryType.contact, ContactRepository.validContacts);
-        contactListType = ContactRepository.validContacts;
+        contactRepository = RepositoryManager.get(RepositoryType.contact, event.chatId);
+        contactListType = event.chatId;
         setupChatContacts(event.chatId);
       } catch (error) {
         yield ContactListStateFailure(error: error.toString());
@@ -118,7 +118,10 @@ class ContactListBloc extends Bloc<ContactListEvent, ContactListState> {
       contactIds = List.from(await _context.getContacts(2, null));
     }else if(contactListType == ContactRepository.blockedContacts){
       contactIds = List.from(await _context.getBlockedContacts());
-    }else{
+    }else if(contactListType != ContactRepository.inviteContacts){
+      contactIds = List.from(await _context.getChatContacts(contactListType));
+    }
+    else{
       return;
     }
     contactRepository.putIfAbsent(ids: contactIds);

--- a/lib/src/data/contact_repository.dart
+++ b/lib/src/data/contact_repository.dart
@@ -68,6 +68,8 @@ class ContactRepository extends Repository<Contact> {
       contactIds = List.from(await context.getContacts(2, null));
     }else if(_listType == blockedContacts){
       contactIds = List.from(await context.getBlockedContacts());
+    }else if(_listType != inviteContacts){
+      contactIds = List.from(await context.getChatContacts(_listType));
     }else{
       return;
     }

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -143,9 +143,9 @@ class AppLocalizations {
 
   String get coreDraft => Intl.message('Draft', name: 'coreDraft');
 
-  String get coreMembers => Intl.message('%1\$d member(s)', name: 'createChatWith');
+  String get coreMembers => Intl.message('%1\$d member(s)', name: 'coreMembers');
 
-  String get coreContacts => Intl.message('%1\$d contact(s)', name: 'createChatWith');
+  String get coreContacts => Intl.message('%1\$d contact(s)', name: 'coreContacts');
 
   String get coreVoiceMessage => Intl.message('Voice message', name: 'coreVoiceMessage');
 
@@ -278,7 +278,13 @@ class AppLocalizations {
   String get chatListEmpty => Intl.message('No chats', name: 'chatListEmpty');
 
   //Chat profile view
+  String get chatProfileBlockContactInfoText => Intl.message('Do you want to block the contact?', name: 'chatProfileBlockContactInfoText');
+
   String get chatProfileBlockContactButtonText => Intl.message('Block contact', name: 'chatProfileBlockContactButtonText');
+
+  String get chatProfileClipboardToastMessage => Intl.message('Email copied to clipboard', name: 'chatProfileClipboardToastMessage');
+
+  String chatProfileGroupMemberCounter(memberCount) => Intl.message('$memberCount member(s)', name: 'chatProfileGroupMemberCounter', args: [memberCount]);
 
   // Create chat
   String get createChatTitle => Intl.message('Create chat', name: 'createChatTitle');

--- a/lib/src/utils/styles.dart
+++ b/lib/src/utils/styles.dart
@@ -83,3 +83,8 @@ final messageTimeText = TextStyle(
   color: messageTimeForeground,
   fontSize: 12,
 );
+
+const chatProfileAvatarInitialText = TextStyle(
+  color: Colors.white,
+  fontSize: 50.0
+);


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-talk/issues/36

**Describe what the problem was / what the new feature is**
The user can tap on the avatar/name section in the chat AppBar to see the ChatProfileView. This view has an avatar and the username & email (or in a group just the group name). In a single chat the user can tap on the email to copy it to the clipboard and he can block the user. In a Group Chat we have a list of all members of the group,.

**Describe your solution**
The ChatProfileView loads the chat and differentiates between single and group chats. Then the ChatProfileSingleView/ChatProfileGroupView is called and build the expected view.

**Additional context**
The function to tap the email in the single chat to copy it to clipboard and list all members of a group chat are implemented. I also set the chatId as the indicator for the ChatListRepository. If not I get ALL contacts in the group member list. If the single Chat is the self talk chat, than the block button is not shown.