### PR TITLE
fixed Invites are not removed if a new chat is created #44 OT-149

### DIFF
--- a/lib/src/chat/change_chat_bloc.dart
+++ b/lib/src/chat/change_chat_bloc.dart
@@ -46,6 +46,7 @@ import 'package:bloc/bloc.dart';
 import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:ox_talk/src/chat/change_chat_event.dart';
 import 'package:ox_talk/src/chat/change_chat_state.dart';
+import 'package:ox_talk/src/data/chat_message_repository.dart';
 import 'package:ox_talk/src/data/chat_repository.dart';
 import 'package:ox_talk/src/data/repository.dart';
 import 'package:ox_talk/src/data/repository_manager.dart';
@@ -75,7 +76,13 @@ class ChangeChatBloc extends Bloc<ChangeChatEvent, ChangeChatState> {
     Context context = Context();
     var chatId;
     if (contactId != null) {
+      Repository<ChatMsg> inviteMessageRepository = RepositoryManager.get(RepositoryType.chatMessage, ChatMessageRepository.inviteChatId);
+      inviteMessageRepository.clear();
       chatId = await context.createChatByContactId(contactId);
+//      var chatMessages = await context.getChatMessages(chatId);
+//      for(int msgId in chatMessages){
+//        inviteMessageRepository.remove(msgId);
+//      }
     } else if (messageId != null) {
       messagesRepository.clear();
       chatId = await context.createChatByMessageId(messageId);

--- a/lib/src/chat/chat_profile_group_view.dart
+++ b/lib/src/chat/chat_profile_group_view.dart
@@ -43,7 +43,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_talk/src/chat/chat_profile_group_contact_item.dart';
-import 'package:ox_talk/src/contact/contact_item.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';

--- a/lib/src/chat/chat_profile_view.dart
+++ b/lib/src/chat/chat_profile_view.dart
@@ -1,25 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_talk/src/chat/chat_bloc.dart';
 import 'package:ox_talk/src/chat/chat_event.dart';
 import 'package:ox_talk/src/chat/chat_profile_group_view.dart';
 import 'package:ox_talk/src/chat/chat_profile_single_view.dart';
 import 'package:ox_talk/src/chat/chat_state.dart';
-import 'package:ox_talk/src/contact/contact_change_bloc.dart';
-import 'package:ox_talk/src/contact/contact_change_event.dart';
-import 'package:ox_talk/src/contact/contact_item.dart';
-import 'package:ox_talk/src/contact/contact_item_bloc.dart';
-import 'package:ox_talk/src/contact/contact_item_event.dart';
-import 'package:ox_talk/src/contact/contact_item_state.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
-import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
-import 'package:ox_talk/src/utils/dimensions.dart';
-import 'package:ox_talk/src/utils/styles.dart';
-import 'package:ox_talk/src/utils/toast.dart';
 
 class ChatProfileView extends StatefulWidget {
   final int _chatId;


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-talk/issues/44

**Describe what the problem was / what the new feature is**
The invites are not removed when a Chat was created with a contact from the invites.

**Describe your solution**
The MessageRepository for the invites is cleared after creating a chat.  We do the same by creating a Chat from an invite.

**Additional context**
Removed some unused Imports.
