### PR TITLE
Add new message counter for chats #54

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -99,6 +99,7 @@ class _ChatScreenState extends State<ChatScreen> {
   void initState() {
     super.initState();
     _chatBloc.dispatch(RequestChat(widget._chatId));
+    _chatBloc.dispatch(ChatMarkNoticed());
     _messagesBloc.dispatch(RequestMessages(widget._chatId));
     final contactImportObservable = new Observable<ChatComposerState>(_chatComposerBloc.state);
     contactImportObservable.listen((state) => handleChatComposer(state));

--- a/lib/src/chat/chat_bloc.dart
+++ b/lib/src/chat/chat_bloc.dart
@@ -75,20 +75,32 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
         name: event.name,
         subTitle: event.subTitle,
         color: event.color,
+        freshMessageCount: event.freshMessageCount,
         isSelfTalk: event.isSelfTalk,
         isGroupChat: event.isGroupChat,
       );
+    } else if(event is ChatMarkNoticed){
+      _markNoticedChat();
     }
   }
 
   void _setupChat() async {
+    Context context = Context();
     Chat chat = chatRepository.get(_chatId);
     String name = await chat.getName();
     String subTitle = await chat.getSubtitle();
     int colorValue = await chat.getColor();
+    int freshMessageCount = await context.getFreshMessageCount(_chatId);
     bool isSelfTalk = await chat.isSelfTalk();
     _isGroup = await chat.isGroup();
     Color color = rgbColorFromInt(colorValue);
-    dispatch(ChatLoaded(name, subTitle, color, isSelfTalk, _isGroup));
+    dispatch(ChatLoaded(name, subTitle, color, freshMessageCount, isSelfTalk, _isGroup));
+  }
+
+  void _markNoticedChat() async{
+    Context context = Context();
+    await context.markNoticedChat(_chatId);
+    Chat chat = chatRepository.get(_chatId);
+    chat.setLastUpdate();
   }
 }

--- a/lib/src/chat/chat_event.dart
+++ b/lib/src/chat/chat_event.dart
@@ -54,8 +54,11 @@ class ChatLoaded extends ChatEvent {
   final String name;
   final String subTitle;
   final Color color;
+  final int freshMessageCount;
   final bool isSelfTalk;
   final bool isGroupChat;
 
-  ChatLoaded(this.name, this.subTitle, this.color, this.isSelfTalk, this.isGroupChat);
+  ChatLoaded(this.name, this.subTitle, this.color, this.freshMessageCount, this.isSelfTalk, this.isGroupChat);
 }
+
+class ChatMarkNoticed extends ChatEvent {}

--- a/lib/src/chat/chat_state.dart
+++ b/lib/src/chat/chat_state.dart
@@ -75,10 +75,11 @@ class ChatStateSuccess extends ChatState {
   final String name;
   final String subTitle;
   final Color color;
+  final int freshMessageCount;
   final bool isSelfTalk;
   final bool isGroupChat;
 
-  ChatStateSuccess({@required this.name, @required this.subTitle, @required this.color, @required this.isSelfTalk, @required this.isGroupChat})
+  ChatStateSuccess({@required this.name, @required this.subTitle, @required this.color, @required this.freshMessageCount, @required this.isSelfTalk, @required this.isGroupChat})
       : super(
           isLoading: false,
           isSuccess: true,

--- a/lib/src/chatlist/chat_list_item.dart
+++ b/lib/src/chatlist/chat_list_item.dart
@@ -77,10 +77,12 @@ class _ChatListItemState extends State<ChatListItem> {
         String name;
         String subTitle;
         Color color;
+        int freshMessageCount;
         if (state is ChatStateSuccess) {
           name = state.name;
           subTitle = state.subTitle;
           color = state.color;
+          freshMessageCount = state.freshMessageCount;
         } else {
           name = "";
           subTitle = "";
@@ -89,6 +91,7 @@ class _ChatListItemState extends State<ChatListItem> {
           title: name,
           subTitle: subTitle,
           color: color,
+          freshMessageCount: freshMessageCount,
           subTitleIcon: _chatBloc.isGroup
               ? Icon(
                   Icons.group,

--- a/lib/src/widgets/avatar_list_item.dart
+++ b/lib/src/widgets/avatar_list_item.dart
@@ -51,6 +51,7 @@ class AvatarListItem extends StatelessWidget {
   final String subTitle;
   final String imagePath;
   final Color color;
+  final int freshMessageCount;
   final Function onTap;
   final Widget titleIcon;
   final Widget subTitleIcon;
@@ -63,6 +64,7 @@ class AvatarListItem extends StatelessWidget {
       this.avatarIcon,
       this.imagePath,
       this.color,
+      this.freshMessageCount,
       this.titleIcon,
       this.subTitleIcon});
 
@@ -118,6 +120,27 @@ class AvatarListItem extends StatelessWidget {
                   ],
                 ),
               ),
+            ),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                freshMessageCount != null && freshMessageCount > 0 ?
+                Container(
+                  margin: EdgeInsets.only(top: 8.0),
+                  padding: EdgeInsets.only(left: 8.0,right: 8.0, top: 4.0, bottom: 4.0),
+                  decoration: BoxDecoration(
+                    color: chatMain,
+                    borderRadius: BorderRadius.circular(100)
+                  ),
+                  child: Text(
+                    freshMessageCount <= 99 ? freshMessageCount.toString() : "99+",
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 12.0
+                    ),
+                  ),
+                ) : Container()
+              ],
             )
           ],
         ),


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-talk/issues/54

**Describe what the problem was / what the new feature is**
There was no indicator for new messages in the ChatList.

**Describe your solution**
I added an indicator in the AvatarListItem to show how many new messages are in a chat.

**Additional context**
A chat is marked as noticed when it is opened. This clears the indicator in the ChatList.