### PR TITLE
Contacts from invites are shown in the contact list #66 OT-166

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -113,7 +113,7 @@ class _ChatScreenState extends State<ChatScreen> {
     } else if (state is ChatComposerRecordingAudioStopped) {
       if (state.filePath != null && state.shouldSend) {
         _filePath = state.filePath;
-        _onMessageSend(Context.msgVoice);
+        _onMessageSend(ChatMsg.typeVoice);
       }
       setState(() {
         _composingAudioTimer = null;
@@ -367,23 +367,23 @@ class _ChatScreenState extends State<ChatScreen> {
       if (knownType == null) {
         switch (_selectedFileType) {
           case FileType.IMAGE:
-            type = Context.msgImage;
+            type = ChatMsg.typeImage;
             break;
           case FileType.VIDEO:
-            type = Context.msgVideo;
+            type = ChatMsg.typeVideo;
             break;
           case FileType.AUDIO:
-            type = Context.msgAudio;
+            type = ChatMsg.typeAudio;
             break;
           case FileType.CUSTOM:
             if (_selectedExtension == "gif") {
-              type = Context.msgGif;
+              type = ChatMsg.typeGif;
             } else {
-              type = Context.msgFile;
+              type = ChatMsg.typeFile;
             }
             break;
           case FileType.ANY:
-            type = Context.msgFile;
+            type = ChatMsg.typeFile;
             break;
         }
       } else {

--- a/lib/src/chat/chat_composer_bloc.dart
+++ b/lib/src/chat/chat_composer_bloc.dart
@@ -129,10 +129,10 @@ class ChatComposerBloc extends Bloc<ChatComposerEvent, ChatComposerState> {
     int type;
     if (pickImage) {
       file = await ImagePicker.pickImage(source: ImageSource.camera);
-      type = Dcc.Context.msgImage;
+      type = Dcc.ChatMsg.typeImage;
     } else {
       file = await ImagePicker.pickVideo(source: ImageSource.camera);
-      type = Dcc.Context.msgVideo;
+      type = Dcc.ChatMsg.typeVideo;
     }
     if (file != null) {
       dispatch(StopImageOrVideoRecording(filePath: file.path, type: type));

--- a/lib/src/chat/chat_profile_group_view.dart
+++ b/lib/src/chat/chat_profile_group_view.dart
@@ -67,7 +67,7 @@ class _ChatProfileGroupViewState extends State<ChatProfileGroupView> {
   @override
   void initState() {
     super.initState();
-    _contactListBloc.dispatch(RequestChatContacts(widget._chatId));
+    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: widget._chatId));
   }
 
   @override

--- a/lib/src/chat/chat_profile_view.dart
+++ b/lib/src/chat/chat_profile_view.dart
@@ -28,7 +28,7 @@ class _ChatProfileViewState extends State<ChatProfileView> {
   void initState() {
     super.initState();
     _chatBloc.dispatch(RequestChat(widget._chatId));
-    _contactListBloc.dispatch(RequestChatContacts(widget._chatId));
+    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: widget._chatId));
   }
 
   @override

--- a/lib/src/chat/create_chat.dart
+++ b/lib/src/chat/create_chat.dart
@@ -48,6 +48,7 @@ import 'package:ox_talk/src/contact/contact_item.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
+import 'package:ox_talk/src/data/contact_repository.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
 import 'package:ox_talk/src/utils/dimensions.dart';
@@ -64,7 +65,7 @@ class _CreateChatState extends State<CreateChat> {
   @override
   void initState(){
     super.initState();
-    _contactListBloc.dispatch(RequestContacts());
+    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: ContactRepository.validContacts));
   }
 
   @override

--- a/lib/src/chat/create_group_chat.dart
+++ b/lib/src/chat/create_group_chat.dart
@@ -49,6 +49,7 @@ import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
 import 'package:ox_talk/src/contact/selectable_contact_item.dart';
 import 'package:ox_talk/src/data/chat_repository.dart';
+import 'package:ox_talk/src/data/contact_repository.dart';
 import 'package:ox_talk/src/data/repository.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
@@ -70,7 +71,7 @@ class _CreateGroupChatState extends State<CreateGroupChat> {
   @override
   void initState() {
     super.initState();
-    _contactListBloc.dispatch(RequestContacts());
+    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: ContactRepository.validContacts));
     chatRepository = ChatRepository(Chat.getCreator());
   }
 

--- a/lib/src/chatlist/chat_list_bloc.dart
+++ b/lib/src/chatlist/chat_list_bloc.dart
@@ -44,7 +44,6 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:delta_chat_core/delta_chat_core.dart';
-import 'package:flutter/material.dart';
 import 'package:ox_talk/src/chatlist/chat_list_event.dart';
 import 'package:ox_talk/src/chatlist/chat_list_state.dart';
 import 'package:ox_talk/src/data/repository.dart';

--- a/lib/src/contact/contact_blocked_list.dart
+++ b/lib/src/contact/contact_blocked_list.dart
@@ -39,13 +39,14 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
  * for more details.
  */
- 
+
  import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_talk/src/contact/contact_item.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
+import 'package:ox_talk/src/data/contact_repository.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
 import 'package:ox_talk/src/utils/colors.dart';
@@ -55,7 +56,7 @@ class ContactBlockedList extends StatefulWidget {
    @override
    _ContactBlockedListState createState() => _ContactBlockedListState();
  }
- 
+
  class _ContactBlockedListState extends State<ContactBlockedList> {
    ContactListBloc _contactListBloc = ContactListBloc();
    Navigation navigation = Navigation();
@@ -63,7 +64,7 @@ class ContactBlockedList extends StatefulWidget {
    @override
   void initState() {
     super.initState();
-    _contactListBloc.dispatch(RequestBlockedContacts());
+    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: ContactRepository.blockedContacts));
   }
 
    @override
@@ -112,4 +113,3 @@ class ContactBlockedList extends StatefulWidget {
        });
    }
  }
- 

--- a/lib/src/contact/contact_list.dart
+++ b/lib/src/contact/contact_list.dart
@@ -50,6 +50,7 @@ import 'package:ox_talk/src/contact/contact_item.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
+import 'package:ox_talk/src/data/contact_repository.dart';
 import 'package:ox_talk/src/l10n/localizations.dart';
 import 'package:ox_talk/src/navigation/navigation.dart';
 import 'package:ox_talk/src/utils/colors.dart';
@@ -112,12 +113,12 @@ class _ContactListState extends State<ContactListView> {
   @override
   void initState() {
     super.initState();
-    _contactListBloc.dispatch(RequestContacts());
+    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: ContactRepository.validContacts));
     setupContactImport();
     _searchController.addListener(() {
       var query = _searchController.text;
       if (query.isEmpty) {
-        _contactListBloc.dispatch(RequestContacts());
+        _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: ContactRepository.validContacts));
       } else {
         _contactListBloc.dispatch(FilterContacts(query: query));
       }

--- a/lib/src/data/contact_repository_updater.dart
+++ b/lib/src/data/contact_repository_updater.dart
@@ -40,29 +40,26 @@
  * for more details.
  */
 
-import 'package:meta/meta.dart';
+import 'package:delta_chat_core/delta_chat_core.dart';
+import 'package:ox_talk/src/data/contact_repository.dart';
 
-abstract class ContactListEvent {}
+mixin ContactRepositoryUpdater {
 
-class RequestContacts extends ContactListEvent {
-  final int listTypeOrChatId;
+  Future<List<int>> getContactIdsAfterUpdate(int listTypeOrChatId) async {
+    Context context = Context();
+    List<int> contactIds;
+    if (listTypeOrChatId == ContactRepository.validContacts) {
+      contactIds = List.from(await context.getContacts(2, null));
+    } else if (listTypeOrChatId == ContactRepository.blockedContacts) {
+      contactIds = List.from(await context.getBlockedContacts());
+    } else if (listTypeOrChatId == ContactRepository.inviteContacts) {
+      contactIds = List.from(await context.getChatContacts(Chat.typeInvite));
+    } else if (listTypeOrChatId != null) {
+      contactIds = List.from(await context.getChatContacts(listTypeOrChatId));
+    } else {
+      return List();
+    }
+    return contactIds;
+  }
 
-  RequestContacts({@required this.listTypeOrChatId});
-}
-
-class ContactsChanged extends ContactListEvent {}
-
-class BlockedContactsChanged extends ContactListEvent {}
-
-class FilterContacts extends ContactListEvent {
-  final String query;
-
-  FilterContacts({@required this.query});
-}
-
-class ContactsFiltered extends ContactListEvent {
-  final List<int> ids;
-  final List<int> lastUpdates;
-
-  ContactsFiltered({@required this.ids, @required this.lastUpdates});
 }

--- a/lib/src/widgets/avatar_list_item.dart
+++ b/lib/src/widgets/avatar_list_item.dart
@@ -127,7 +127,7 @@ class AvatarListItem extends StatelessWidget {
             Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
-                timestamp != null ? Text(
+                timestamp != null && timestamp != 0 ? Text(
                   getChatListTime(context, timestamp),
                   style: TextStyle(
                     color: freshMessageCount != null && freshMessageCount > 0 ? Colors.black : Colors.grey,


### PR DESCRIPTION
**Link to the given issue**
#66 

**Describe what the problem was / what the new feature is**
Contacts from invites where shown in the normal contact list.

**Describe your solution**
Fixed the wrong displaying by separating the valid and invite contacts into different repositories. See https://github.com/open-xchange/ox-talk/compare/issue-66?expand=1#diff-5fe772f9d2183d2cff78acbbc5513f0c for the actual fix

**Additional context**

- Removed duplicated constants for message types
- Simplified https://github.com/open-xchange/ox-talk/compare/issue-66?expand=1#diff-b7fd1bfde16ac22624f1b064bba32cbc by removing the different events and adding the contact type to the default request event. Also cleaned up the file
- Created https://github.com/open-xchange/ox-talk/compare/issue-66?expand=1#diff-368c78fef78c2e75603d767c03506722 to avoid duplicated code
- If a chat had no messages the date 01.01.1970 (timestamp == 0) was shown, added https://github.com/open-xchange/ox-talk/compare/issue-66?expand=1#diff-9a5a2b2f9e7124d79b4245c235d19d18 to fix this
