### PR TITLE
Chat list item UI problems #81

### DIFF
--- a/lib/src/chat/chat_create_group_participants.dart
+++ b/lib/src/chat/chat_create_group_participants.dart
@@ -50,7 +50,6 @@ import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
 import 'package:ox_talk/src/contact/contact_search_controller_mixin.dart';
 import 'package:ox_talk/src/contact/contact_item_selectable.dart';
-import 'package:ox_talk/src/data/chat_repository.dart';
 import 'package:ox_talk/src/data/contact_repository.dart';
 import 'package:ox_talk/src/data/repository.dart';
 import 'package:ox_talk/src/data/repository_manager.dart';

--- a/lib/src/chat/chat_create_group_settings.dart
+++ b/lib/src/chat/chat_create_group_settings.dart
@@ -51,7 +51,6 @@ import 'package:ox_talk/src/contact/contact_item.dart';
 import 'package:ox_talk/src/contact/contact_list_bloc.dart';
 import 'package:ox_talk/src/contact/contact_list_event.dart';
 import 'package:ox_talk/src/contact/contact_list_state.dart';
-import 'package:ox_talk/src/data/chat_repository.dart';
 import 'package:ox_talk/src/data/contact_repository.dart';
 import 'package:ox_talk/src/data/repository.dart';
 import 'package:ox_talk/src/data/repository_manager.dart';

--- a/lib/src/chatlist/chat_list.dart
+++ b/lib/src/chatlist/chat_list.dart
@@ -101,7 +101,10 @@ class _ChatListState extends State<ChatList> {
 
   Widget buildListViewItems(List<int> chatIds, List<int> chatLastUpdateValues) {
     return ListView.builder(
-      padding: EdgeInsets.only(top: listItemPadding),
+      padding: EdgeInsets.only(
+        left: listItemPadding,
+        right: listItemPadding,
+        top: listItemPadding),
       itemCount: chatIds.length,
       itemBuilder: (BuildContext context, int index) {
         var chatId = chatIds[index];

--- a/lib/src/chatlist/chat_list_item.dart
+++ b/lib/src/chatlist/chat_list_item.dart
@@ -82,8 +82,8 @@ class _ChatListItemState extends State<ChatListItem> {
         String name;
         String subTitle;
         Color color;
-        int freshMessageCount;
-        int timestamp;
+        int freshMessageCount = 0;
+        int timestamp = 0;
         String preview;
         if (state is ChatStateSuccess) {
           name = state.name;

--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -46,7 +46,6 @@ import 'package:ox_talk/src/chat/chat.dart';
 import 'package:ox_talk/src/contact/contact_change_bloc.dart';
 import 'package:ox_talk/src/contact/contact_change_event.dart';
 import 'package:ox_talk/src/contact/contact_change_state.dart';
-import 'package:ox_talk/src/data/chat_repository.dart';
 import 'package:ox_talk/src/data/repository.dart';
 import 'package:ox_talk/src/data/repository_manager.dart';
 import 'package:ox_talk/src/utils/dimensions.dart';

--- a/lib/src/contact/contact_item_bloc.dart
+++ b/lib/src/contact/contact_item_bloc.dart
@@ -47,7 +47,6 @@ import 'package:bloc/bloc.dart';
 import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:ox_talk/src/contact/contact_item_event.dart';
 import 'package:ox_talk/src/contact/contact_item_state.dart';
-import 'package:ox_talk/src/data/contact_repository.dart';
 import 'package:ox_talk/src/data/repository.dart';
 import 'package:ox_talk/src/data/repository_manager.dart';
 import 'package:ox_talk/src/utils/colors.dart';

--- a/lib/src/widgets/avatar_list_item.dart
+++ b/lib/src/widgets/avatar_list_item.dart
@@ -66,10 +66,10 @@ class AvatarListItem extends StatelessWidget {
       this.avatarIcon,
       this.imagePath,
       this.color,
-      this.freshMessageCount,
+      this.freshMessageCount = 0,
       this.titleIcon,
       this.subTitleIcon,
-      this.timestamp});
+      this.timestamp = 0});
 
   @override
   Widget build(BuildContext context) {
@@ -77,28 +77,24 @@ class AvatarListItem extends StatelessWidget {
       onTap: () => onTap(title, subTitle),
       child: Container(
         padding: const EdgeInsets.only(
-          left: listItemPadding,
-          right: listItemPadding,
           top: listItemPaddingSmall,
         ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             avatarIcon == null
-                ? Avatar(
-                    imagePath: imagePath,
-                    initials: getInitials(),
-                    color: color,
-                  )
-                : CircleAvatar(
-                    radius: listAvatarRadius,
-                    foregroundColor: listAvatarForegroundColor,
-                    child: Icon(avatarIcon),
-                  ),
+              ? Avatar(
+                  imagePath: imagePath,
+                  initials: getInitials(),
+                  color: color,
+                )
+              : CircleAvatar(
+                  radius: listAvatarRadius,
+                  foregroundColor: listAvatarForegroundColor,
+                  child: Icon(avatarIcon),
+                ),
             Expanded(
-              child: Padding(
-                padding: EdgeInsets.symmetric(horizontal: listItemPadding),
-                child: Column(
+              child: Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: <Widget>[
                     Row(
@@ -107,13 +103,27 @@ class AvatarListItem extends StatelessWidget {
                           padding: const EdgeInsets.only(right: iconTextPadding),
                           child: titleIcon != null ? titleIcon : Container(),
                         ),
-                        Expanded(child: getTitle()),
+                        Expanded(
+                          child: getTitle()
+                        ),
+                        Visibility(
+                          visible: timestamp != null && timestamp != 0,
+                          child: Text(
+                            getChatListTime(context, timestamp),
+                            style: TextStyle(
+                              color: freshMessageCount != null && freshMessageCount > 0 ? Colors.black : Colors.grey,
+                              fontWeight: freshMessageCount != null && freshMessageCount > 0 ? FontWeight.bold : FontWeight.normal,
+                              fontSize: 14.0
+                            ),
+                          )
+                        ),
                       ],
                     ),
                     Padding(
-                        padding: EdgeInsets.symmetric(
-                      vertical: listItemPaddingSmall,
-                    )),
+                      padding: EdgeInsets.symmetric(
+                        vertical: listItemPaddingSmall,
+                      )
+                    ),
                     Row(
                       children: <Widget>[
                         Padding(
@@ -121,38 +131,23 @@ class AvatarListItem extends StatelessWidget {
                           child: subTitleIcon != null ? subTitleIcon : Container(),
                         ),
                         Expanded(child: getSubTitle()),
+                        Visibility(
+                          visible: freshMessageCount != null && freshMessageCount > 0,
+                          child: Container(
+                            padding: EdgeInsets.only(left: 8.0, right: 8.0, top: 4.0, bottom: 4.0),
+                            decoration: BoxDecoration(color: chatMain, borderRadius: BorderRadius.circular(100)),
+                            child: Text(
+                              freshMessageCount <= 99 ? freshMessageCount.toString() : "99+",
+                              style: TextStyle(color: Colors.white, fontSize: 12.0),
+                            ),
+                          ),
+                        ),
                       ],
                     ),
                     Divider(),
                   ],
                 ),
-              ),
             ),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                timestamp != null && timestamp != 0
-                    ? Text(
-                        getChatListTime(context, timestamp),
-                        style: TextStyle(
-                            color: freshMessageCount != null && freshMessageCount > 0 ? Colors.black : Colors.grey,
-                            fontWeight: freshMessageCount != null && freshMessageCount > 0 ? FontWeight.bold : FontWeight.normal,
-                            fontSize: 14.0),
-                      )
-                    : Container(),
-                freshMessageCount != null && freshMessageCount > 0
-                    ? Container(
-                        margin: EdgeInsets.only(top: 8.0),
-                        padding: EdgeInsets.only(left: 8.0, right: 8.0, top: 4.0, bottom: 4.0),
-                        decoration: BoxDecoration(color: chatMain, borderRadius: BorderRadius.circular(100)),
-                        child: Text(
-                          freshMessageCount <= 99 ? freshMessageCount.toString() : "99+",
-                          style: TextStyle(color: Colors.white, fontSize: 12.0),
-                        ),
-                      )
-                    : Container()
-              ],
-            )
           ],
         ),
       ),
@@ -160,25 +155,27 @@ class AvatarListItem extends StatelessWidget {
   }
 
   StatelessWidget getTitle() {
-    return title != null
-        ? Text(
-            title,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: chatItemTitle,
-          )
-        : Container();
+    return Visibility(
+      visible: title != null,
+      child: Text(
+        title != null ? title : "",
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: chatItemTitle,
+      )
+    );
   }
 
   StatelessWidget getSubTitle() {
-    return subTitle != null
-        ? Text(
-            subTitle,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(color: textLessImportant),
-          )
-        : Container();
+    return Visibility(
+      visible: subTitle != null,
+      child: Text(
+        subTitle != null ? subTitle :"",
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(color: textLessImportant),
+      )
+    );
   }
 
   String getInitials() {


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-talk/issues/81

**Describe what the problem was / what the new feature is**
The message preview is cut by the date / time indicator
The divider is cut by the date / time indicator and by the message counter

**Describe your solution**
Chat name / date are in a row and preview / message counter in another row. These two rows are in a column. The left and right padding of the items is now set on the parent. This means the list has a left and right padding and not the items.

**Additional context**
Removed unused imports and added Visibility Widget instead of Container() in avatar_list_item.