### PR TITLE
Broken BottomSheet in iOS in chat view #613

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -47,6 +47,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet.dart';
 import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet_action.dart';
 import 'package:ox_coi/src/brandable/brandable_icon.dart';
 import 'package:ox_coi/src/brandable/custom_theme.dart';
@@ -661,9 +662,8 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
     showNavigatableBottomSheet(
         context: context,
         navigatable: Navigatable(Type.addAttachmentModal),
-        bottomSheet: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
+        bottomSheet: AdaptiveBottomSheet(
+          actions: <Widget>[
             AdaptiveBottomSheetAction(
               key: Key(keyAttachmentAddImage),
               title: Text(L10n.get(L.image)),

--- a/lib/src/widgets/modal_builder.dart
+++ b/lib/src/widgets/modal_builder.dart
@@ -44,6 +44,7 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet.dart';
 import 'package:ox_coi/src/adaptive_widgets/adaptive_dialog.dart';
 import 'package:ox_coi/src/adaptive_widgets/adaptive_dialog_action.dart';
 import 'package:ox_coi/src/l10n/l.dart';
@@ -55,7 +56,7 @@ import '../utils/keyMapping.dart';
 
 showNavigatableBottomSheet({
   @required BuildContext context,
-  @required Widget bottomSheet,
+  @required AdaptiveBottomSheet bottomSheet,
   @required Navigatable navigatable,
   Navigatable previousNavigatable,
 }) {


### PR DESCRIPTION
**Link to the given issue**
Fixes #663

**Describe what the problem was / what the new feature is**
AdaptiveBottomSheet wasn't used.

**Describe your solution**
AdaptiveBottomSheet is now used.

**Additional context**
To test on Android:
- Change https://github.com/open-xchange/ox-coi/blob/b03d7f6d38041ee814514a21399d5916871e559b/lib/src/adaptive_widgets/adaptive_widget.dart#L18 to `isAndroid`
- Change https://github.com/open-xchange/ox-coi/blob/97380e779e914da8815cf41c38145332488e7c89/lib/src/widgets/modal_builder.dart#L66 to 'isAndroid`
